### PR TITLE
Polish tooltip and settings UI interactions

### DIFF
--- a/dist/balaclava-tooltip.meta.js
+++ b/dist/balaclava-tooltip.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Balaclava Tooltip
 // @namespace   https://github.com/NHG-Design/balaclava
-// @version     1.0.1
+// @version     1.0.2
 // @description Universal tooltip injection for userscript managers
 // @author      Yukio [906148]
 // @license     MIT

--- a/dist/balaclava-tooltip.user.js
+++ b/dist/balaclava-tooltip.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Balaclava Tooltip
 // @namespace   https://github.com/NHG-Design/balaclava
-// @version     1.0.1
+// @version     1.0.2
 // @description Universal tooltip injection for userscript managers
 // @author      Yukio [906148]
 // @license     MIT
@@ -22,7 +22,7 @@
   var ARROW_OFFSET_MIN = 10;
   var ARROW_OFFSET_MAX = 90;
   var ARROW_OFFSET_DEFAULT = 50;
-  var VERSION = "1.0.1";
+  var VERSION = "1.0.2";
   var VALID_POSITIONS = /* @__PURE__ */ new Set(["top", "bottom", "left", "right"]);
   var VALID_THEMES = /* @__PURE__ */ new Set(["system", "dark", "light", "custom"]);
   var CUSTOM_THEME_KEYS = /* @__PURE__ */ new Set(["bgColor", "textColor", "borderColor", "shadowColor"]);
@@ -204,6 +204,11 @@
         transform: scale(0.97);
       }
 
+      .balaclava-tooltip.is-exiting {
+        opacity: 0;
+        transform: scale(0.97);
+      }
+
       @media (prefers-color-scheme: light) {
         .balaclava-tooltip.is-theme-system {
           --balaclava-tooltip-bg: ${THEME_TOKENS.light.bgColor};
@@ -289,6 +294,7 @@
         trackTargetPosition();
       });
     }, hideTooltip = function() {
+      tooltipCooldownEnd = Date.now() + 600;
       cleanupTooltip();
     }, configure = function(userConfig = {}) {
       const nextConfig = { ...config };
@@ -326,17 +332,40 @@
       const controller = new AbortController();
       const { signal } = controller;
       let detached = false;
-      const onShow = () => showTooltip(element, resolveContent(content, element), options);
-      const onHide = () => {
+      let hoverTimer = null;
+      const doShow = () => showTooltip(element, resolveContent(content, element), options);
+      const onMouseEnter = () => {
+        if (Date.now() < tooltipCooldownEnd) {
+          nextShowInstant = true;
+          doShow();
+          nextShowInstant = false;
+        } else {
+          hoverTimer = setTimeout(() => {
+            hoverTimer = null;
+            doShow();
+          }, 200);
+        }
+      };
+      const onMouseLeave = () => {
+        if (hoverTimer !== null) {
+          clearTimeout(hoverTimer);
+          hoverTimer = null;
+        }
         if (targetElement === element) hideTooltip();
       };
-      element.addEventListener("mouseenter", onShow, { signal });
-      element.addEventListener("mouseleave", onHide, { signal });
-      element.addEventListener("focus", onShow, { signal });
-      element.addEventListener("blur", onHide, { signal });
+      element.addEventListener("mouseenter", onMouseEnter, { signal });
+      element.addEventListener("mouseleave", onMouseLeave, { signal });
+      element.addEventListener("focus", doShow, { signal });
+      element.addEventListener("blur", () => {
+        if (targetElement === element) hideTooltip();
+      }, { signal });
       const detach = function detach2() {
         if (detached) return;
         detached = true;
+        if (hoverTimer !== null) {
+          clearTimeout(hoverTimer);
+          hoverTimer = null;
+        }
         controller.abort();
         attachmentDetachers.delete(detach2);
         if (targetElement === element) {
@@ -420,7 +449,8 @@
       }
       tooltipEl = document.createElement("div");
       tooltipEl.id = tooltipId;
-      tooltipEl.className = `${getTooltipClassName()} is-entering`;
+      tooltipEl.className = nextShowInstant ? getTooltipClassName() : `${getTooltipClassName()} is-entering`;
+      if (nextShowInstant) tooltipEl.setAttribute("data-instant", "");
       tooltipEl.setAttribute("role", "tooltip");
       tooltipEl.setAttribute("aria-live", "polite");
       tooltipEl.style.setProperty("--arrow-offset", `${arrowOffset}%`);
@@ -443,11 +473,13 @@
         tooltipEl.appendChild(arrowEl);
       }
       shadow.appendChild(tooltipEl);
-      requestAnimationFrame(() => {
-        if (tooltipEl) {
-          tooltipEl.classList.remove("is-entering");
-        }
-      });
+      if (!nextShowInstant) {
+        requestAnimationFrame(() => {
+          if (tooltipEl) {
+            tooltipEl.classList.remove("is-entering");
+          }
+        });
+      }
     }, setupIntersectionObserver = function() {
       cleanupIntersectionObserver();
       if (!targetElement || typeof IntersectionObserver === "undefined") return;
@@ -475,8 +507,15 @@
         scrollFrameId = null;
       }
       if (tooltipEl) {
-        tooltipEl.remove();
+        const exiting = tooltipEl;
         tooltipEl = null;
+        exiting.removeAttribute("id");
+        exiting.classList.add("is-exiting");
+        const remove = () => {
+          if (exiting.isConnected) exiting.remove();
+        };
+        exiting.addEventListener("transitionend", remove, { once: true });
+        setTimeout(remove, 200);
       }
       cleanupIntersectionObserver();
       isVisible = false;
@@ -711,6 +750,8 @@
     let isVisible = false;
     let globalListenersController = null;
     let readyController = null;
+    let tooltipCooldownEnd = 0;
+    let nextShowInstant = false;
     const tooltipId = `balaclava-tt-${Math.random().toString(36).slice(2, 11)}`;
     let attachedElements = /* @__PURE__ */ new WeakMap();
     const attachmentDetachers = /* @__PURE__ */ new Set();

--- a/dist/pyromaniacs-ledger.meta.js
+++ b/dist/pyromaniacs-ledger.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Torn Pyromaniac's Ledger
 // @namespace   https://github.com/NHG-Design/balaclava
-// @version     0.4.3
+// @version     0.4.4
 // @description Arson profit-per-nerve calculator and strategy guide for Torn's Crimes page
 // @icon        https://www.google.com/s2/favicons?sz=64&domain=torn.com
 // @author      Yukio [906148]

--- a/dist/pyromaniacs-ledger.user.js
+++ b/dist/pyromaniacs-ledger.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Torn Pyromaniac's Ledger
 // @namespace   https://github.com/NHG-Design/balaclava
-// @version     0.4.3
+// @version     0.4.4
 // @description Arson profit-per-nerve calculator and strategy guide for Torn's Crimes page
 // @icon        https://www.google.com/s2/favicons?sz=64&domain=torn.com
 // @author      Yukio [906148]
@@ -2934,7 +2934,7 @@
   var ARROW_OFFSET_MIN = 10;
   var ARROW_OFFSET_MAX = 90;
   var ARROW_OFFSET_DEFAULT = 50;
-  var VERSION = "1.0.1";
+  var VERSION = "1.0.2";
   var VALID_POSITIONS = /* @__PURE__ */ new Set(["top", "bottom", "left", "right"]);
   var VALID_THEMES = /* @__PURE__ */ new Set(["system", "dark", "light", "custom"]);
   var CUSTOM_THEME_KEYS = /* @__PURE__ */ new Set(["bgColor", "textColor", "borderColor", "shadowColor"]);
@@ -3116,6 +3116,11 @@
         transform: scale(0.97);
       }
 
+      .balaclava-tooltip.is-exiting {
+        opacity: 0;
+        transform: scale(0.97);
+      }
+
       @media (prefers-color-scheme: light) {
         .balaclava-tooltip.is-theme-system {
           --balaclava-tooltip-bg: ${THEME_TOKENS.light.bgColor};
@@ -3201,6 +3206,7 @@
         trackTargetPosition();
       });
     }, hideTooltip = function() {
+      tooltipCooldownEnd = Date.now() + 600;
       cleanupTooltip();
     }, configure = function(userConfig = {}) {
       const nextConfig = { ...config };
@@ -3238,17 +3244,40 @@
       const controller = new AbortController();
       const { signal } = controller;
       let detached = false;
-      const onShow = () => showTooltip(element, resolveContent(content, element), options);
-      const onHide = () => {
+      let hoverTimer = null;
+      const doShow = () => showTooltip(element, resolveContent(content, element), options);
+      const onMouseEnter = () => {
+        if (Date.now() < tooltipCooldownEnd) {
+          nextShowInstant = true;
+          doShow();
+          nextShowInstant = false;
+        } else {
+          hoverTimer = setTimeout(() => {
+            hoverTimer = null;
+            doShow();
+          }, 200);
+        }
+      };
+      const onMouseLeave = () => {
+        if (hoverTimer !== null) {
+          clearTimeout(hoverTimer);
+          hoverTimer = null;
+        }
         if (targetElement === element) hideTooltip();
       };
-      element.addEventListener("mouseenter", onShow, { signal });
-      element.addEventListener("mouseleave", onHide, { signal });
-      element.addEventListener("focus", onShow, { signal });
-      element.addEventListener("blur", onHide, { signal });
+      element.addEventListener("mouseenter", onMouseEnter, { signal });
+      element.addEventListener("mouseleave", onMouseLeave, { signal });
+      element.addEventListener("focus", doShow, { signal });
+      element.addEventListener("blur", () => {
+        if (targetElement === element) hideTooltip();
+      }, { signal });
       const detach = function detach2() {
         if (detached) return;
         detached = true;
+        if (hoverTimer !== null) {
+          clearTimeout(hoverTimer);
+          hoverTimer = null;
+        }
         controller.abort();
         attachmentDetachers.delete(detach2);
         if (targetElement === element) {
@@ -3332,7 +3361,8 @@
       }
       tooltipEl = document.createElement("div");
       tooltipEl.id = tooltipId;
-      tooltipEl.className = `${getTooltipClassName()} is-entering`;
+      tooltipEl.className = nextShowInstant ? getTooltipClassName() : `${getTooltipClassName()} is-entering`;
+      if (nextShowInstant) tooltipEl.setAttribute("data-instant", "");
       tooltipEl.setAttribute("role", "tooltip");
       tooltipEl.setAttribute("aria-live", "polite");
       tooltipEl.style.setProperty("--arrow-offset", `${arrowOffset}%`);
@@ -3355,11 +3385,13 @@
         tooltipEl.appendChild(arrowEl);
       }
       shadow.appendChild(tooltipEl);
-      requestAnimationFrame(() => {
-        if (tooltipEl) {
-          tooltipEl.classList.remove("is-entering");
-        }
-      });
+      if (!nextShowInstant) {
+        requestAnimationFrame(() => {
+          if (tooltipEl) {
+            tooltipEl.classList.remove("is-entering");
+          }
+        });
+      }
     }, setupIntersectionObserver = function() {
       cleanupIntersectionObserver();
       if (!targetElement || typeof IntersectionObserver === "undefined") return;
@@ -3387,8 +3419,15 @@
         scrollFrameId = null;
       }
       if (tooltipEl) {
-        tooltipEl.remove();
+        const exiting = tooltipEl;
         tooltipEl = null;
+        exiting.removeAttribute("id");
+        exiting.classList.add("is-exiting");
+        const remove = () => {
+          if (exiting.isConnected) exiting.remove();
+        };
+        exiting.addEventListener("transitionend", remove, { once: true });
+        setTimeout(remove, 200);
       }
       cleanupIntersectionObserver();
       isVisible = false;
@@ -3623,6 +3662,8 @@
     let isVisible = false;
     let globalListenersController = null;
     let readyController = null;
+    let tooltipCooldownEnd = 0;
+    let nextShowInstant = false;
     const tooltipId = `balaclava-tt-${Math.random().toString(36).slice(2, 11)}`;
     let attachedElements = /* @__PURE__ */ new WeakMap();
     const attachmentDetachers = /* @__PURE__ */ new Set();
@@ -4064,12 +4105,17 @@
     color: #bbb;
     cursor: pointer;
     border-radius: 4px;
-    padding: 2px 7px;
+    padding: 3px 7px;
     font-size: 13px;
-    line-height: 1.4;
+    line-height: 1;
     user-select: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 100ms ease-out;
 }
 #pyro-settings-btn:hover { background: rgba(255,255,255,0.08); color: #fff; }
+#pyro-settings-btn:active { transform: scale(0.94); }
 #pyro-settings-panel {
     position: absolute;
     top: calc(100% + 6px);
@@ -4080,8 +4126,21 @@
     border-radius: 6px;
     min-width: 290px;
     max-width: 360px;
-    box-shadow: 0 6px 20px rgba(0,0,0,0.55);
+    box-shadow: 0 8px 28px oklch(6% 0.01 260 / 0.6);
     overflow: hidden;
+    transform-origin: top right;
+    transform: scale(0.95);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 150ms ease-out, opacity 150ms ease-out, visibility 0ms linear 150ms;
+}
+#pyro-settings-panel.is-open {
+    transform: scale(1);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transition: transform 150ms ease-out, opacity 150ms ease-out, visibility 0ms linear 0ms;
 }
 .pyro-tab-bar {
     display: flex;
@@ -4096,7 +4155,7 @@
     color: #777;
     cursor: pointer;
     padding: 7px 2px;
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -4111,7 +4170,7 @@
 .pyro-s-group { margin-bottom: 10px; }
 .pyro-s-group:last-child { margin-bottom: 0; }
 .pyro-s-group-title {
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -4174,8 +4233,10 @@
     padding: 4px 9px;
     font-size: 11px;
     white-space: nowrap;
+    transition: transform 100ms ease-out;
 }
 .pyro-s-btn:hover:not(:disabled) { background: #303030; color: #fff; }
+.pyro-s-btn:active:not(:disabled) { transform: scale(0.97); }
 .pyro-s-btn:disabled { opacity: 0.35; cursor: default; }
 .pyro-s-status {
     font-size: 10px;
@@ -4533,10 +4594,9 @@
     btn.id = "pyro-settings-btn";
     btn.setAttribute("aria-label", "Pyromaniac's Ledger settings");
     btn.setAttribute("aria-expanded", "false");
-    btn.textContent = "\u2699";
+    btn.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>';
     const panel = el2("div");
     panel.id = "pyro-settings-panel";
-    panel.setAttribute("hidden", "");
     const activeTab2 = ctx.getActiveTab() || "prices";
     panel.appendChild(buildTabBar(activeTab2, (tabId) => {
       ctx.setActiveTab(tabId);
@@ -4550,16 +4610,16 @@
     anchor.appendChild(wrap);
     btn.addEventListener("click", (e) => {
       e.stopPropagation();
-      const hidden = panel.hasAttribute("hidden");
-      panel.toggleAttribute("hidden", !hidden);
-      btn.setAttribute("aria-expanded", String(hidden));
-      if (hidden && (ctx.getActiveTab() || "prices") === "debug") {
+      const isOpen = panel.classList.contains("is-open");
+      panel.classList.toggle("is-open", !isOpen);
+      btn.setAttribute("aria-expanded", String(!isOpen));
+      if (!isOpen && (ctx.getActiveTab() || "prices") === "debug") {
         rerenderTab(panel, "debug", ctx);
       }
     });
     document.addEventListener("click", (e) => {
       if (!wrap.contains(e.target)) {
-        panel.setAttribute("hidden", "");
+        panel.classList.remove("is-open");
         btn.setAttribute("aria-expanded", "false");
       }
     }, { passive: true });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "vite build && node scripts/build-userscripts.mjs",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "cf:deploy": "pnpm build && wrangler pages deploy .svelte-kit/cloudflare",
@@ -18,6 +18,7 @@
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@types/node": "^25.9.1",
+    "esbuild": "^0.28.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tsx": "^4.22.3",

--- a/scripts/build-userscripts.mjs
+++ b/scripts/build-userscripts.mjs
@@ -19,7 +19,7 @@ const USERSCRIPTS = [
         metadata: {
             ...COMMON_METADATA,
             name: 'Balaclava Tooltip',
-            version: '1.0.1',
+            version: '1.0.2',
             description: 'Universal tooltip injection for userscript managers',
             updateURL: `${DIST_BASE}/balaclava-tooltip.meta.js`,
             downloadURL: `${DIST_BASE}/balaclava-tooltip.user.js`,
@@ -33,7 +33,7 @@ const USERSCRIPTS = [
         metadata: {
             ...COMMON_METADATA,
             name: "Torn Pyromaniac's Ledger",
-            version: '0.4.3',
+            version: '0.4.4',
             description: "Arson profit-per-nerve calculator and strategy guide for Torn's Crimes page",
             icon: 'https://www.google.com/s2/favicons?sz=64&domain=torn.com',
             updateURL: `${DIST_BASE}/pyromaniacs-ledger.meta.js`,

--- a/scripts/build-userscripts.mjs
+++ b/scripts/build-userscripts.mjs
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'fs';
+import { build } from 'esbuild';
 
 const DIST_BASE = 'https://raw.githubusercontent.com/NHG-Design/balaclava/main/dist';
 const BALACLAVA_BASE = 'https://balaclava.app';
@@ -84,12 +85,15 @@ function createUserscriptHeader(metadata) {
 execSync('pnpm exec tsx scripts/dump-strategies.ts', { stdio: 'inherit' });
 
 for (const userscript of USERSCRIPTS) {
-    execSync(
-        `pnpm exec esbuild ${userscript.entry}` +
-        ' --bundle --format=iife --target=es2020 --tree-shaking=true' +
-        ` --outfile=${userscript.outfile} --log-level=info`,
-        { stdio: 'inherit' }
-    );
+    await build({
+        entryPoints: [userscript.entry],
+        bundle: true,
+        format: 'iife',
+        target: 'es2020',
+        treeShaking: true,
+        outfile: userscript.outfile,
+        logLevel: 'info',
+    });
 
     const header = createUserscriptHeader(userscript.metadata);
     const bundle = readFileSync(userscript.outfile, 'utf8');

--- a/src/userscripts/balaclava-tooltip/index.ts
+++ b/src/userscripts/balaclava-tooltip/index.ts
@@ -128,6 +128,8 @@ if (!rootWindow[API_NAME]?.version) {
     let isVisible = false;
     let globalListenersController: AbortController | null = null;
     let readyController: AbortController | null = null;
+    let tooltipCooldownEnd = 0;
+    let nextShowInstant = false;
 
     const tooltipId = `balaclava-tt-${Math.random().toString(36).slice(2, 11)}`;
     let attachedElements = new WeakMap<HTMLElement, () => void>();
@@ -303,6 +305,11 @@ if (!rootWindow[API_NAME]?.version) {
         transform: scale(0.97);
       }
 
+      .balaclava-tooltip.is-exiting {
+        opacity: 0;
+        transform: scale(0.97);
+      }
+
       @media (prefers-color-scheme: light) {
         .balaclava-tooltip.is-theme-system {
           --balaclava-tooltip-bg: ${THEME_TOKENS.light.bgColor};
@@ -416,6 +423,7 @@ if (!rootWindow[API_NAME]?.version) {
     }
 
     function hideTooltip(): void {
+        tooltipCooldownEnd = Date.now() + 600;
         cleanupTooltip();
     }
 
@@ -467,21 +475,44 @@ if (!rootWindow[API_NAME]?.version) {
         const controller = new AbortController();
         const { signal } = controller;
         let detached = false;
+        let hoverTimer: ReturnType<typeof setTimeout> | null = null;
 
-        const onShow = (): void => showTooltip(element, resolveContent(content, element), options);
-        const onHide = (): void => {
+        const doShow = (): void => showTooltip(element, resolveContent(content, element), options);
+
+        const onMouseEnter = (): void => {
+            if (Date.now() < tooltipCooldownEnd) {
+                nextShowInstant = true;
+                doShow();
+                nextShowInstant = false;
+            } else {
+                hoverTimer = setTimeout(() => {
+                    hoverTimer = null;
+                    doShow();
+                }, 200);
+            }
+        };
+
+        const onMouseLeave = (): void => {
+            if (hoverTimer !== null) {
+                clearTimeout(hoverTimer);
+                hoverTimer = null;
+            }
             if (targetElement === element) hideTooltip();
         };
 
-        element.addEventListener('mouseenter', onShow, { signal });
-        element.addEventListener('mouseleave', onHide, { signal });
-        element.addEventListener('focus', onShow, { signal });
-        element.addEventListener('blur', onHide, { signal });
+        element.addEventListener('mouseenter', onMouseEnter, { signal });
+        element.addEventListener('mouseleave', onMouseLeave, { signal });
+        element.addEventListener('focus', doShow, { signal });
+        element.addEventListener('blur', () => { if (targetElement === element) hideTooltip(); }, { signal });
 
         const detach = function detach(): void {
             if (detached) return;
 
             detached = true;
+            if (hoverTimer !== null) {
+                clearTimeout(hoverTimer);
+                hoverTimer = null;
+            }
             controller.abort();
             attachmentDetachers.delete(detach);
 
@@ -605,7 +636,8 @@ if (!rootWindow[API_NAME]?.version) {
 
         tooltipEl = document.createElement('div');
         tooltipEl.id = tooltipId;
-        tooltipEl.className = `${getTooltipClassName()} is-entering`;
+        tooltipEl.className = nextShowInstant ? getTooltipClassName() : `${getTooltipClassName()} is-entering`;
+        if (nextShowInstant) tooltipEl.setAttribute('data-instant', '');
         tooltipEl.setAttribute('role', 'tooltip');
         tooltipEl.setAttribute('aria-live', 'polite');
         tooltipEl.style.setProperty('--arrow-offset', `${arrowOffset}%`);
@@ -634,11 +666,13 @@ if (!rootWindow[API_NAME]?.version) {
 
         shadow.appendChild(tooltipEl);
 
-        requestAnimationFrame(() => {
-            if (tooltipEl) {
-                tooltipEl.classList.remove('is-entering');
-            }
-        });
+        if (!nextShowInstant) {
+            requestAnimationFrame(() => {
+                if (tooltipEl) {
+                    tooltipEl.classList.remove('is-entering');
+                }
+            });
+        }
     }
 
     function setupIntersectionObserver(): void {
@@ -678,8 +712,13 @@ if (!rootWindow[API_NAME]?.version) {
         }
 
         if (tooltipEl) {
-            tooltipEl.remove();
+            const exiting = tooltipEl;
             tooltipEl = null;
+            exiting.removeAttribute('id');
+            exiting.classList.add('is-exiting');
+            const remove = () => { if (exiting.isConnected) exiting.remove(); };
+            exiting.addEventListener('transitionend', remove, { once: true });
+            setTimeout(remove, 200);
         }
 
         cleanupIntersectionObserver();

--- a/src/userscripts/balaclava-tooltip/index.ts
+++ b/src/userscripts/balaclava-tooltip/index.ts
@@ -6,7 +6,7 @@ const SAFEZONE = 8;
 const ARROW_OFFSET_MIN = 10;
 const ARROW_OFFSET_MAX = 90;
 const ARROW_OFFSET_DEFAULT = 50;
-const VERSION = '1.0.1';
+const VERSION = '1.0.2';
 
 type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
 type TooltipTheme = 'system' | 'dark' | 'light' | 'custom';

--- a/src/userscripts/pyromaniacs-ledger/settings.ts
+++ b/src/userscripts/pyromaniacs-ledger/settings.ts
@@ -65,12 +65,17 @@ export function injectSettingsStyles(): void {
     color: #bbb;
     cursor: pointer;
     border-radius: 4px;
-    padding: 2px 7px;
+    padding: 3px 7px;
     font-size: 13px;
-    line-height: 1.4;
+    line-height: 1;
     user-select: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 100ms ease-out;
 }
 #pyro-settings-btn:hover { background: rgba(255,255,255,0.08); color: #fff; }
+#pyro-settings-btn:active { transform: scale(0.94); }
 #pyro-settings-panel {
     position: absolute;
     top: calc(100% + 6px);
@@ -81,8 +86,21 @@ export function injectSettingsStyles(): void {
     border-radius: 6px;
     min-width: 290px;
     max-width: 360px;
-    box-shadow: 0 6px 20px rgba(0,0,0,0.55);
+    box-shadow: 0 8px 28px oklch(6% 0.01 260 / 0.6);
     overflow: hidden;
+    transform-origin: top right;
+    transform: scale(0.95);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 150ms ease-out, opacity 150ms ease-out, visibility 0ms linear 150ms;
+}
+#pyro-settings-panel.is-open {
+    transform: scale(1);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transition: transform 150ms ease-out, opacity 150ms ease-out, visibility 0ms linear 0ms;
 }
 .pyro-tab-bar {
     display: flex;
@@ -97,7 +115,7 @@ export function injectSettingsStyles(): void {
     color: #777;
     cursor: pointer;
     padding: 7px 2px;
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -112,7 +130,7 @@ export function injectSettingsStyles(): void {
 .pyro-s-group { margin-bottom: 10px; }
 .pyro-s-group:last-child { margin-bottom: 0; }
 .pyro-s-group-title {
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -175,8 +193,10 @@ export function injectSettingsStyles(): void {
     padding: 4px 9px;
     font-size: 11px;
     white-space: nowrap;
+    transition: transform 100ms ease-out;
 }
 .pyro-s-btn:hover:not(:disabled) { background: #303030; color: #fff; }
+.pyro-s-btn:active:not(:disabled) { transform: scale(0.97); }
 .pyro-s-btn:disabled { opacity: 0.35; cursor: default; }
 .pyro-s-status {
     font-size: 10px;
@@ -620,11 +640,10 @@ export function injectSettings(root: Element, ctx: SettingsCtx): void {
     btn.id = 'pyro-settings-btn';
     btn.setAttribute('aria-label', "Pyromaniac's Ledger settings");
     btn.setAttribute('aria-expanded', 'false');
-    btn.textContent = '⚙';
+    btn.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>';
 
     const panel = el('div');
     panel.id = 'pyro-settings-panel';
-    panel.setAttribute('hidden', '');
 
     const activeTab = ctx.getActiveTab() || 'prices';
     panel.appendChild(buildTabBar(activeTab, tabId => {
@@ -642,17 +661,17 @@ export function injectSettings(root: Element, ctx: SettingsCtx): void {
 
     btn.addEventListener('click', e => {
         e.stopPropagation();
-        const hidden = panel.hasAttribute('hidden');
-        panel.toggleAttribute('hidden', !hidden);
-        btn.setAttribute('aria-expanded', String(hidden));
-        if (hidden && (ctx.getActiveTab() || 'prices') === 'debug') {
+        const isOpen = panel.classList.contains('is-open');
+        panel.classList.toggle('is-open', !isOpen);
+        btn.setAttribute('aria-expanded', String(!isOpen));
+        if (!isOpen && (ctx.getActiveTab() || 'prices') === 'debug') {
             rerenderTab(panel, 'debug', ctx);
         }
     });
 
     document.addEventListener('click', e => {
         if (!wrap.contains(e.target as Node)) {
-            panel.setAttribute('hidden', '');
+            panel.classList.remove('is-open');
             btn.setAttribute('aria-expanded', 'false');
         }
     }, { passive: true });


### PR DESCRIPTION
Tooltip: add 150ms exit fade (scale+opacity) before DOM removal, 200ms
hover-delay on first activation with instant switching while the cooldown
window is open, wire up data-instant to skip enter animation during rapid
sequential hovering.

Settings: replace ⚙ emoji with SVG gear icon, add scale+opacity open/close
animation on the panel (top-right origin, 150ms ease-out), add :active
press feedback on all buttons, tint drop shadow toward bg hue, bump
group-title from 9px to 10px and tab labels from 10px to 11px.

https://claude.ai/code/session_01Dg8CSAM6TTsVBxPP9GmALj