### PR TITLE
[codex] fold interface skill knowledge

### DIFF
--- a/.agents/skills/interface/SKILL.md
+++ b/.agents/skills/interface/SKILL.md
@@ -33,7 +33,9 @@ Every design task is **brand** (marketing, landing, portfolio — design IS the 
 |---|---|
 | Animation, motion, easing, transitions, springs, gestures, performance | MANDATORY READ [reference/animation.md](reference/animation.md) |
 | Components: buttons, popovers, tooltips, forms, loading/empty/error states | MANDATORY READ [reference/components.md](reference/components.md) |
-| Color, typography, theme (dark/light), layout, spacing, shadows | MANDATORY READ [reference/design-laws.md](reference/design-laws.md) |
+| Color, theme (dark/light), layout, spacing, shadows | MANDATORY READ [reference/design-laws.md](reference/design-laws.md) |
+| Typography, measure, text wrapping, font rendering, numeric alignment | MANDATORY READ [reference/typography.md](reference/typography.md) |
+| Final refinement, micro-details, visual rhythm, "make this feel better" | MANDATORY READ [reference/polish.md](reference/polish.md) |
 | Code review, "what's wrong with this", "make this better", UX critique | MANDATORY READ [reference/review.md](reference/review.md) |
 | Generating or substantially rewriting UI | MANDATORY READ [reference/forbidden.md](reference/forbidden.md) |
 
@@ -50,13 +52,11 @@ For deeper content beyond the primary references above:
 | Cognitive load and IA | [reference/cognitive-load.md](reference/cognitive-load.md) |
 | Color and contrast deep-dive | [reference/color-and-contrast.md](reference/color-and-contrast.md) |
 | UX writing and microcopy | [reference/ux-writing.md](reference/ux-writing.md) |
-| Typography deep-dive | [reference/typography.md](reference/typography.md) |
 | Responsive design | [reference/responsive-design.md](reference/responsive-design.md) |
 | Interaction design patterns | [reference/interaction-design.md](reference/interaction-design.md) |
 | Spatial design | [reference/spatial-design.md](reference/spatial-design.md) |
 | Amplifying bland designs | [reference/bolder.md](reference/bolder.md) |
 | Quieting overstimulating designs | [reference/quieter.md](reference/quieter.md) |
-| Polish pass before shipping | [reference/polish.md](reference/polish.md) |
 | Delight and personality | [reference/delight.md](reference/delight.md) |
 | First-run / onboarding flows | [reference/onboard.md](reference/onboard.md) |
 | Error states, i18n, edge cases | [reference/harden.md](reference/harden.md) |
@@ -65,7 +65,7 @@ For deeper content beyond the primary references above:
 | Overdrive: push past conventional limits | [reference/overdrive.md](reference/overdrive.md) |
 | Live browser iteration | MANDATORY READ [reference/live.md](reference/live.md) — invoke `node scripts/live.mjs` |
 
-If the request doesn't map clearly to any reference ("make this feel better", "this isn't working") — treat it as a UX critique: load `review.md` first, diagnose, then load additional references based on what you find. Multiple references may be loaded simultaneously when a task genuinely spans domains (e.g., "review this animated component" → load both `animation.md` and `review.md`). When generating any UI — not just reviewing — always load `reference/forbidden.md` regardless of which other reference the task maps to.
+If the request doesn't map clearly to any reference, decide whether the problem is diagnosis or refinement. "This isn't working" and other failure-language requests are UX critique: load `review.md` first, diagnose, then load additional references based on what you find. "Make this feel better", "polish this", and other refinement-language requests are polish tasks: load `polish.md` first, then pull in additional references where the defects cluster. Multiple references may be loaded simultaneously when a task genuinely spans domains (e.g., "review this animated component" → load both `animation.md` and `review.md`). When generating any UI — not just reviewing — always load `reference/forbidden.md` regardless of which other reference the task maps to.
 
 ## NEVER
 

--- a/.agents/skills/interface/reference/animation.md
+++ b/.agents/skills/interface/reference/animation.md
@@ -163,6 +163,21 @@ Press: slow and deliberate. Release: always snappy.
 .item:nth-child(3) { animation-delay: 100ms; }
 ```
 
+### Contextual icon swaps
+
+When an icon appears or swaps because state changed, animate the icon itself instead of hard-toggling visibility. `opacity`, `scale`, and a small `blur` create a more physical handoff than a binary swap.
+
+- **Reliable values**: `scale(0.25)` to `scale(1)`, `opacity: 0` to `1`, `filter: blur(4px)` to `blur(0)`
+- **With a motion library**: use a spring with `bounce: 0` for these tiny stateful transitions
+- **Without a motion library**: keep both icons in the DOM, absolutely stack them, and crossfade with CSS transitions
+
+### Skip first-render entrance motion
+
+Default-state UI should not replay its enter animation on initial page load. Save entrance motion for intentional arrivals, not for "this component existed when the page mounted."
+
+- In React Motion / Framer Motion, `initial={false}` is the usual fix for default-state elements.
+- Verify that disabling first-render motion does not suppress a deliberate hero or onboarding entrance.
+
 ### List item enter/exit: opacity + height
 
 When animating list items in and out, animating `opacity` alone looks wrong (item disappears but space remains) and `height` alone is janky (layout triggers). The correct combination is `opacity` + `max-height` (or `height` via JS). There is no formula — tune both values together. A good starting point: `opacity 200ms ease-out, max-height 250ms ease-out`.

--- a/.agents/skills/interface/reference/design-laws.md
+++ b/.agents/skills/interface/reference/design-laws.md
@@ -6,6 +6,8 @@
 
 **Never `#000` or `#fff`.** Tint every neutral toward the brand hue. Chroma of 0.005–0.01 is enough to feel intentional without being visible.
 
+**Exception:** image outlines are one of the rare cases where pure black or pure white at low opacity is correct. The outline is a neutral separator, not a themed surface. See [reference/polish.md](polish.md).
+
 **Pick a color strategy before picking colors:**
 
 | Strategy | Surface coverage | Use case |

--- a/.agents/skills/interface/reference/interaction-design.md
+++ b/.agents/skills/interface/reference/interaction-design.md
@@ -40,6 +40,14 @@ button:focus-visible {
 - Offset from element (not inside it)
 - Consistent across all interactive elements
 
+## Hit Areas and Press Feedback
+
+**Minimum hit area**: 44x44px on touch-first UI, or at least 40x40px where density is unavoidable. If the visible control is smaller, expand the interactive box with padding or a pseudo-element rather than scaling the artwork up.
+
+**Collision rule**: Expanded hit areas must never overlap neighboring controls. Shrink the invisible area if needed, but keep it as large as possible without creating ambiguity.
+
+**Pressed state should feel tactile**: For buttons, chips, icon buttons, and tappable cards, a subtle `scale(0.96)` on press is usually enough. Do not go smaller than `0.95`; it turns theatrical fast. Skip press animation on extremely high-frequency keyboard-driven actions or contexts where any motion reads as latency.
+
 ## Form Design: The Non-Obvious
 
 **Placeholders aren't labels.** They disappear on input. Always use visible `<label>` elements. **Validate on blur**, not on every keystroke (exception: password strength). Place errors **below** fields with `aria-describedby` connecting them.

--- a/.agents/skills/interface/reference/polish.md
+++ b/.agents/skills/interface/reference/polish.md
@@ -57,6 +57,8 @@ Work through these dimensions methodically:
 - **Optical alignment**: Adjust for visual weight (icons may need offset for optical centering)
 - **Responsive consistency**: Spacing and alignment work at all breakpoints
 - **Grid adherence**: Elements snap to baseline grid
+- **Concentric border radius**: For tightly nested rounded surfaces, `outer radius = inner radius + padding`. If the gap is large, treat them as separate surfaces instead of forcing the math.
+- **Icon-side asymmetry is often correct**: Text-plus-icon buttons frequently need about 2px less padding on the icon side. Play triangles and directional glyphs usually need optical nudges too.
 
 **Check**:
 - Enable grid overlay and verify alignment
@@ -133,6 +135,8 @@ Every interactive element needs all states:
 - **Alt text**: All images have descriptive alt text
 - **Loading states**: Images don't cause layout shift, proper aspect ratios
 - **Retina support**: 2x assets for high-DPI screens
+- **Image outlines**: Use `outline`, not `border`, for subtle image separation. In light mode use `rgba(0, 0, 0, 0.1)`; in dark mode use `rgba(255, 255, 255, 0.1)` with `outline-offset: -1px`. This is one of the rare justified pure black/white exceptions.
+- **Shadows over borders for depth**: Cards, buttons, and floating containers usually want layered transparent shadows instead of solid borders. Keep borders for dividers, separators, and focusable form controls where edge definition matters more than depth.
 
 ### Forms & Inputs
 

--- a/.agents/skills/interface/reference/review.md
+++ b/.agents/skills/interface/reference/review.md
@@ -27,6 +27,7 @@ Scan for these in order. Each maps to a row in the output table.
 
 | Issue | Fix |
 |---|---|
+| Same border radius on nested surfaces | Make the outer radius equal inner radius plus padding between them |
 | `transition: all` | `transition: transform 200ms ease-out` (specify exact properties) |
 | Entry animation from `scale(0)` | Start from `scale(0.95)` with `opacity: 0` |
 | `ease-in` on any UI element | Switch to `ease-out` or custom `cubic-bezier(0.23, 1, 0.32, 1)` |
@@ -38,14 +39,20 @@ Scan for these in order. Each maps to a row in the output table.
 | Shorthand motion properties on GPU-critical path | Use full `transform` string for hardware acceleration |
 | Same speed for enter and exit | Make exit faster (e.g., enter 2s deliberate, exit 200ms snap) |
 | List items appearing simultaneously | Add stagger delay (30–80ms per item) |
+| Text + icon button feels off-center | Tighten icon-side padding slightly or fix the SVG for optical alignment |
+| Dynamic numbers jitter width while updating | Apply `font-variant-numeric: tabular-nums` |
+| Heading or short copy leaves an orphaned last word | Use `text-wrap: balance` for headings or `text-wrap: pretty` for short body copy |
+| Missing tactile pressed state on tappable controls | Add a subtle active-state press, typically `scale(0.96)` |
 | Gradient text | Replace with solid color + weight/size emphasis |
 | Side-stripe border as accent | Full border, background tint, or icon instead |
 | `border-left/right` >1px as card accent | Rewrite structure entirely |
-| Pure `#000` or `#fff` | Tint neutrals toward brand hue (OKLCH chroma 0.005–0.01) |
+| Pure `#000` or `#fff` on text or surfaces | Tint neutrals toward brand hue (OKLCH chroma 0.005–0.01) |
+| Image feels pasted onto the page | Add a 1px outline: black/10 in light mode, white/10 in dark mode, with `outline-offset: -1px` |
 | Identical repeating card grid | Asymmetric layout, bento, zig-zag, or vary size/proportion |
 | Modal for simple confirmation | Inline action, slide-over, or progressive disclosure |
 | Full-height section using `h-screen` | Replace with `min-height: 100dvh` |
 | Generic placeholder names/avatars | Invent realistic names; use intentional placeholders |
+| Interactive target under 44x44px | Expand hit area with padding or a pseudo-element without overlapping neighbors |
 | Em dash in copy | Comma, colon, semicolon, or parentheses |
 
 ## UX Critique vs. Code Review

--- a/.agents/skills/interface/reference/typography.md
+++ b/.agents/skills/interface/reference/typography.md
@@ -135,9 +135,20 @@ h1, h2, h3 { text-wrap: balance; }
 /* Reduce orphans and ragged endings in long prose */
 article p { text-wrap: pretty; }
 
+/* Root-level rendering polish for macOS */
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 /* Variable fonts: pick the right optical-size master automatically */
 body { font-optical-sizing: auto; }
 ```
+
+- **Use `text-wrap: balance` only on short headings and short text blocks.** Browsers cap how much text they will rebalance, so applying it to long paragraphs signals intent the browser will ignore.
+- **Use `text-wrap: pretty` as the default for short-to-medium body copy.** Captions, descriptions, list items, and UI text benefit. Very long text can keep default wrapping.
+- **Apply font smoothing once at the root, not per element.** Inconsistent smoothing between headings and body text reads as a rendering bug, not polish.
+- **Use `tabular-nums` for numbers that change or need alignment.** Counters, timers, prices, dashboards, and numeric table columns qualify. Phone numbers, version strings, and decorative numerals usually do not.
 
 **ALL-CAPS tracking**: capitals sit too close at default spacing. Add 5–12% letter-spacing (`letter-spacing: 0.05em` to `0.12em`) to short all-caps labels, eyebrows, and small headings. Real small caps (via `font-variant-caps`) need the same treatment, slightly gentler.
 

--- a/.claude/skills/interface/SKILL.md
+++ b/.claude/skills/interface/SKILL.md
@@ -33,7 +33,9 @@ Every design task is **brand** (marketing, landing, portfolio — design IS the 
 |---|---|
 | Animation, motion, easing, transitions, springs, gestures, performance | MANDATORY READ [reference/animation.md](reference/animation.md) |
 | Components: buttons, popovers, tooltips, forms, loading/empty/error states | MANDATORY READ [reference/components.md](reference/components.md) |
-| Color, typography, theme (dark/light), layout, spacing, shadows | MANDATORY READ [reference/design-laws.md](reference/design-laws.md) |
+| Color, theme (dark/light), layout, spacing, shadows | MANDATORY READ [reference/design-laws.md](reference/design-laws.md) |
+| Typography, measure, text wrapping, font rendering, numeric alignment | MANDATORY READ [reference/typography.md](reference/typography.md) |
+| Final refinement, micro-details, visual rhythm, "make this feel better" | MANDATORY READ [reference/polish.md](reference/polish.md) |
 | Code review, "what's wrong with this", "make this better", UX critique | MANDATORY READ [reference/review.md](reference/review.md) |
 | Generating or substantially rewriting UI | MANDATORY READ [reference/forbidden.md](reference/forbidden.md) |
 
@@ -50,13 +52,11 @@ For deeper content beyond the primary references above:
 | Cognitive load and IA | [reference/cognitive-load.md](reference/cognitive-load.md) |
 | Color and contrast deep-dive | [reference/color-and-contrast.md](reference/color-and-contrast.md) |
 | UX writing and microcopy | [reference/ux-writing.md](reference/ux-writing.md) |
-| Typography deep-dive | [reference/typography.md](reference/typography.md) |
 | Responsive design | [reference/responsive-design.md](reference/responsive-design.md) |
 | Interaction design patterns | [reference/interaction-design.md](reference/interaction-design.md) |
 | Spatial design | [reference/spatial-design.md](reference/spatial-design.md) |
 | Amplifying bland designs | [reference/bolder.md](reference/bolder.md) |
 | Quieting overstimulating designs | [reference/quieter.md](reference/quieter.md) |
-| Polish pass before shipping | [reference/polish.md](reference/polish.md) |
 | Delight and personality | [reference/delight.md](reference/delight.md) |
 | First-run / onboarding flows | [reference/onboard.md](reference/onboard.md) |
 | Error states, i18n, edge cases | [reference/harden.md](reference/harden.md) |
@@ -65,7 +65,7 @@ For deeper content beyond the primary references above:
 | Overdrive: push past conventional limits | [reference/overdrive.md](reference/overdrive.md) |
 | Live browser iteration | MANDATORY READ [reference/live.md](reference/live.md) — invoke `node scripts/live.mjs` |
 
-If the request doesn't map clearly to any reference ("make this feel better", "this isn't working") — treat it as a UX critique: load `review.md` first, diagnose, then load additional references based on what you find. Multiple references may be loaded simultaneously when a task genuinely spans domains (e.g., "review this animated component" → load both `animation.md` and `review.md`). When generating any UI — not just reviewing — always load `reference/forbidden.md` regardless of which other reference the task maps to.
+If the request doesn't map clearly to any reference, decide whether the problem is diagnosis or refinement. "This isn't working" and other failure-language requests are UX critique: load `review.md` first, diagnose, then load additional references based on what you find. "Make this feel better", "polish this", and other refinement-language requests are polish tasks: load `polish.md` first, then pull in additional references where the defects cluster. Multiple references may be loaded simultaneously when a task genuinely spans domains (e.g., "review this animated component" → load both `animation.md` and `review.md`). When generating any UI — not just reviewing — always load `reference/forbidden.md` regardless of which other reference the task maps to.
 
 ## NEVER
 

--- a/.claude/skills/interface/reference/animation.md
+++ b/.claude/skills/interface/reference/animation.md
@@ -163,6 +163,21 @@ Press: slow and deliberate. Release: always snappy.
 .item:nth-child(3) { animation-delay: 100ms; }
 ```
 
+### Contextual icon swaps
+
+When an icon appears or swaps because state changed, animate the icon itself instead of hard-toggling visibility. `opacity`, `scale`, and a small `blur` create a more physical handoff than a binary swap.
+
+- **Reliable values**: `scale(0.25)` to `scale(1)`, `opacity: 0` to `1`, `filter: blur(4px)` to `blur(0)`
+- **With a motion library**: use a spring with `bounce: 0` for these tiny stateful transitions
+- **Without a motion library**: keep both icons in the DOM, absolutely stack them, and crossfade with CSS transitions
+
+### Skip first-render entrance motion
+
+Default-state UI should not replay its enter animation on initial page load. Save entrance motion for intentional arrivals, not for "this component existed when the page mounted."
+
+- In React Motion / Framer Motion, `initial={false}` is the usual fix for default-state elements.
+- Verify that disabling first-render motion does not suppress a deliberate hero or onboarding entrance.
+
 ### List item enter/exit: opacity + height
 
 When animating list items in and out, animating `opacity` alone looks wrong (item disappears but space remains) and `height` alone is janky (layout triggers). The correct combination is `opacity` + `max-height` (or `height` via JS). There is no formula — tune both values together. A good starting point: `opacity 200ms ease-out, max-height 250ms ease-out`.

--- a/.claude/skills/interface/reference/design-laws.md
+++ b/.claude/skills/interface/reference/design-laws.md
@@ -6,6 +6,8 @@
 
 **Never `#000` or `#fff`.** Tint every neutral toward the brand hue. Chroma of 0.005–0.01 is enough to feel intentional without being visible.
 
+**Exception:** image outlines are one of the rare cases where pure black or pure white at low opacity is correct. The outline is a neutral separator, not a themed surface. See [reference/polish.md](polish.md).
+
 **Pick a color strategy before picking colors:**
 
 | Strategy | Surface coverage | Use case |

--- a/.claude/skills/interface/reference/interaction-design.md
+++ b/.claude/skills/interface/reference/interaction-design.md
@@ -40,6 +40,14 @@ button:focus-visible {
 - Offset from element (not inside it)
 - Consistent across all interactive elements
 
+## Hit Areas and Press Feedback
+
+**Minimum hit area**: 44x44px on touch-first UI, or at least 40x40px where density is unavoidable. If the visible control is smaller, expand the interactive box with padding or a pseudo-element rather than scaling the artwork up.
+
+**Collision rule**: Expanded hit areas must never overlap neighboring controls. Shrink the invisible area if needed, but keep it as large as possible without creating ambiguity.
+
+**Pressed state should feel tactile**: For buttons, chips, icon buttons, and tappable cards, a subtle `scale(0.96)` on press is usually enough. Do not go smaller than `0.95`; it turns theatrical fast. Skip press animation on extremely high-frequency keyboard-driven actions or contexts where any motion reads as latency.
+
 ## Form Design: The Non-Obvious
 
 **Placeholders aren't labels.** They disappear on input. Always use visible `<label>` elements. **Validate on blur**, not on every keystroke (exception: password strength). Place errors **below** fields with `aria-describedby` connecting them.

--- a/.claude/skills/interface/reference/polish.md
+++ b/.claude/skills/interface/reference/polish.md
@@ -57,6 +57,8 @@ Work through these dimensions methodically:
 - **Optical alignment**: Adjust for visual weight (icons may need offset for optical centering)
 - **Responsive consistency**: Spacing and alignment work at all breakpoints
 - **Grid adherence**: Elements snap to baseline grid
+- **Concentric border radius**: For tightly nested rounded surfaces, `outer radius = inner radius + padding`. If the gap is large, treat them as separate surfaces instead of forcing the math.
+- **Icon-side asymmetry is often correct**: Text-plus-icon buttons frequently need about 2px less padding on the icon side. Play triangles and directional glyphs usually need optical nudges too.
 
 **Check**:
 - Enable grid overlay and verify alignment
@@ -133,6 +135,8 @@ Every interactive element needs all states:
 - **Alt text**: All images have descriptive alt text
 - **Loading states**: Images don't cause layout shift, proper aspect ratios
 - **Retina support**: 2x assets for high-DPI screens
+- **Image outlines**: Use `outline`, not `border`, for subtle image separation. In light mode use `rgba(0, 0, 0, 0.1)`; in dark mode use `rgba(255, 255, 255, 0.1)` with `outline-offset: -1px`. This is one of the rare justified pure black/white exceptions.
+- **Shadows over borders for depth**: Cards, buttons, and floating containers usually want layered transparent shadows instead of solid borders. Keep borders for dividers, separators, and focusable form controls where edge definition matters more than depth.
 
 ### Forms & Inputs
 

--- a/.claude/skills/interface/reference/review.md
+++ b/.claude/skills/interface/reference/review.md
@@ -27,6 +27,7 @@ Scan for these in order. Each maps to a row in the output table.
 
 | Issue | Fix |
 |---|---|
+| Same border radius on nested surfaces | Make the outer radius equal inner radius plus padding between them |
 | `transition: all` | `transition: transform 200ms ease-out` (specify exact properties) |
 | Entry animation from `scale(0)` | Start from `scale(0.95)` with `opacity: 0` |
 | `ease-in` on any UI element | Switch to `ease-out` or custom `cubic-bezier(0.23, 1, 0.32, 1)` |
@@ -38,14 +39,20 @@ Scan for these in order. Each maps to a row in the output table.
 | Shorthand motion properties on GPU-critical path | Use full `transform` string for hardware acceleration |
 | Same speed for enter and exit | Make exit faster (e.g., enter 2s deliberate, exit 200ms snap) |
 | List items appearing simultaneously | Add stagger delay (30–80ms per item) |
+| Text + icon button feels off-center | Tighten icon-side padding slightly or fix the SVG for optical alignment |
+| Dynamic numbers jitter width while updating | Apply `font-variant-numeric: tabular-nums` |
+| Heading or short copy leaves an orphaned last word | Use `text-wrap: balance` for headings or `text-wrap: pretty` for short body copy |
+| Missing tactile pressed state on tappable controls | Add a subtle active-state press, typically `scale(0.96)` |
 | Gradient text | Replace with solid color + weight/size emphasis |
 | Side-stripe border as accent | Full border, background tint, or icon instead |
 | `border-left/right` >1px as card accent | Rewrite structure entirely |
-| Pure `#000` or `#fff` | Tint neutrals toward brand hue (OKLCH chroma 0.005–0.01) |
+| Pure `#000` or `#fff` on text or surfaces | Tint neutrals toward brand hue (OKLCH chroma 0.005–0.01) |
+| Image feels pasted onto the page | Add a 1px outline: black/10 in light mode, white/10 in dark mode, with `outline-offset: -1px` |
 | Identical repeating card grid | Asymmetric layout, bento, zig-zag, or vary size/proportion |
 | Modal for simple confirmation | Inline action, slide-over, or progressive disclosure |
 | Full-height section using `h-screen` | Replace with `min-height: 100dvh` |
 | Generic placeholder names/avatars | Invent realistic names; use intentional placeholders |
+| Interactive target under 44x44px | Expand hit area with padding or a pseudo-element without overlapping neighbors |
 | Em dash in copy | Comma, colon, semicolon, or parentheses |
 
 ## UX Critique vs. Code Review

--- a/.claude/skills/interface/reference/typography.md
+++ b/.claude/skills/interface/reference/typography.md
@@ -135,9 +135,20 @@ h1, h2, h3 { text-wrap: balance; }
 /* Reduce orphans and ragged endings in long prose */
 article p { text-wrap: pretty; }
 
+/* Root-level rendering polish for macOS */
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 /* Variable fonts: pick the right optical-size master automatically */
 body { font-optical-sizing: auto; }
 ```
+
+- **Use `text-wrap: balance` only on short headings and short text blocks.** Browsers cap how much text they will rebalance, so applying it to long paragraphs signals intent the browser will ignore.
+- **Use `text-wrap: pretty` as the default for short-to-medium body copy.** Captions, descriptions, list items, and UI text benefit. Very long text can keep default wrapping.
+- **Apply font smoothing once at the root, not per element.** Inconsistent smoothing between headings and body text reads as a rendering bug, not polish.
+- **Use `tabular-nums` for numbers that change or need alignment.** Counters, timers, prices, dashboards, and numeric table columns qualify. Phone numbers, version strings, and decorative numerals usually do not.
 
 **ALL-CAPS tracking**: capitals sit too close at default spacing. Add 5–12% letter-spacing (`letter-spacing: 0.05em` to `0.12em`) to short all-caps labels, eyebrows, and small headings. Real small caps (via `font-variant-caps`) need the same treatment, slightly gentler.
 


### PR DESCRIPTION
## What changed

This folds targeted UI craft guidance from the upstream `make-interfaces-feel-better` skill into both local copies of the `interface` skill: `.claude/skills/interface` and `.agents/skills/interface`.

The update adds focused knowledge delta rather than a separate sibling skill:
- promotes typography and polish to first-class routing targets in `SKILL.md`
- adds micro-detail heuristics for concentric radii, icon-side optical spacing, image-outline exceptions, hit areas, tactile press states, contextual icon swaps, and first-render animation restraint
- expands review heuristics so these cases are catchable during critique, not just generation

## Why

The existing `interface` skill already had the stronger top-level philosophy. The missing value was a set of concrete micro-detail rules that make agents better at final-mile UI decisions and review passes.

Keeping this as a merge avoids duplicate activation paths and keeps the design doctrine in one place.

## Impact

Agents using the `interface` skill now have better routing for typography vs polish tasks and sharper reference guidance for subtle frontend quality issues that were previously implicit.

## Validation

- `git diff --cached --check`
- manual self-review against `ai-forge-create` / `ai-forge-judge` expectations

No app runtime files changed. I did not run `pnpm check` or `pnpm build` for this PR.
