### PR TITLE
Add scenario proposal inbox slice

### DIFF
--- a/docs/scenario-proposals-setup.md
+++ b/docs/scenario-proposals-setup.md
@@ -1,0 +1,141 @@
+# Scenario Proposal Inbox Setup
+
+This document boots issue `#13`: a D1-backed `Scenario Proposal Inbox`, the submitter-facing `Scenario Proposal Form`, and the protected `Scenario Admin` inbox.
+
+## 1. Create the D1 database
+
+Run this once in Cloudflare:
+
+```powershell
+pnpm exec wrangler d1 create balaclava-scenario-proposals
+```
+
+Wrangler will print a `database_id`. Add this block to [wrangler.toml](/X:/Dev/balaclava/wrangler.toml):
+
+```toml
+[[d1_databases]]
+binding = "SCENARIO_PROPOSALS_DB"
+database_name = "balaclava-scenario-proposals"
+database_id = "<paste database_id>"
+migrations_dir = "migrations"
+```
+
+## 2. Apply the schema
+
+Apply the migration locally first:
+
+```powershell
+pnpm exec wrangler d1 migrations apply SCENARIO_PROPOSALS_DB --local
+```
+
+Then apply it to the remote database:
+
+```powershell
+pnpm exec wrangler d1 migrations apply SCENARIO_PROPOSALS_DB --remote
+```
+
+The initial schema lives in [migrations/0001_scenario_proposals.sql](/X:/Dev/balaclava/migrations/0001_scenario_proposals.sql) and already includes the ADR 0004 workflow tables:
+
+- `scenario_submitters`
+- `scenario_submit_tokens`
+- `scenario_proposals`
+- `scenario_supporting_runs`
+- `scenario_triage_records`
+- `scenario_triage_record_members`
+- `scenario_pr_events`
+
+## 3. Configure secrets
+
+Set the three server-only secrets in Cloudflare:
+
+```powershell
+pnpm exec wrangler secret put SCENARIO_ADMIN_USERNAME
+pnpm exec wrangler secret put SCENARIO_ADMIN_PASSWORD_HASH
+pnpm exec wrangler secret put SCENARIO_ADMIN_SESSION_SECRET
+```
+
+For local development, add the same names to `.dev.vars`:
+
+```dotenv
+SCENARIO_ADMIN_USERNAME=replace-me
+SCENARIO_ADMIN_PASSWORD_HASH=replace-me
+SCENARIO_ADMIN_SESSION_SECRET=replace-me
+```
+
+### Generate the password hash
+
+The app verifies the admin password with SHA-256 and stores only the hash:
+
+```powershell
+$value = 'replace-with-admin-password'
+[Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($value))).ToLowerInvariant()
+```
+
+Paste the resulting lowercase hex string into `SCENARIO_ADMIN_PASSWORD_HASH`.
+
+### Generate the session secret
+
+Use a random 32-byte secret for signing the `httpOnly` admin session cookie:
+
+```powershell
+[Convert]::ToBase64String([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32))
+```
+
+## 4. Seed a submitter and hashed submit token
+
+The issue-13 slice intentionally keeps submitter/token management out of the UI. Seed them directly in D1.
+
+Pick a plaintext token, hash it locally, and only store the hash:
+
+```powershell
+$token = 'replace-with-submit-token'
+[Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($token))).ToLowerInvariant()
+```
+
+Use the hash in a D1 SQL session:
+
+```sql
+INSERT INTO scenario_submitters (
+    player_id,
+    player_name,
+    notes,
+    is_active,
+    created_at_utc,
+    updated_at_utc
+) VALUES (
+    123456,
+    'Example Submitter',
+    'Initial allowlisted submitter',
+    1,
+    '2026-06-06T00:00:00.000Z',
+    '2026-06-06T00:00:00.000Z'
+);
+
+INSERT INTO scenario_submit_tokens (
+    id,
+    submitter_id,
+    token_hash,
+    label,
+    created_at_utc
+) VALUES (
+    'replace-with-uuid',
+    (SELECT id FROM scenario_submitters WHERE player_id = 123456),
+    'replace-with-token-hash',
+    'initial token',
+    '2026-06-06T00:00:00.000Z'
+);
+```
+
+You can run those statements with:
+
+```powershell
+pnpm exec wrangler d1 execute SCENARIO_PROPOSALS_DB --remote --file .\seed-scenario-submitter.sql
+```
+
+## 5. Use the feature
+
+- Submitter form: `/scenario-proposals`
+- Admin login: `/scenario-proposals/admin/login`
+- Admin inbox: `/scenario-proposals/admin`
+
+The form only accepts existing canonical `Scenario`s from `src/data/scenarios.ts`. Successful submissions write raw proposals plus structured supporting runs into D1. The admin inbox reads those stored proposals directly; grouping, acceptance previews, repo commits, and PR creation are later issues in the chain.

--- a/migrations/0001_scenario_proposals.sql
+++ b/migrations/0001_scenario_proposals.sql
@@ -1,0 +1,96 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS scenario_submitters (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    player_id INTEGER NOT NULL UNIQUE,
+    player_name TEXT NOT NULL,
+    notes TEXT,
+    is_active INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0, 1)),
+    created_at_utc TEXT NOT NULL,
+    updated_at_utc TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS scenario_submit_tokens (
+    id TEXT PRIMARY KEY,
+    submitter_id INTEGER NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    label TEXT,
+    created_at_utc TEXT NOT NULL,
+    revoked_at_utc TEXT,
+    last_used_at_utc TEXT,
+    FOREIGN KEY (submitter_id) REFERENCES scenario_submitters(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_submit_tokens_submitter_id
+    ON scenario_submit_tokens (submitter_id);
+
+CREATE TABLE IF NOT EXISTS scenario_triage_records (
+    id TEXT PRIMARY KEY,
+    scenario_name TEXT NOT NULL,
+    normalized_patch TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at_utc TEXT NOT NULL,
+    updated_at_utc TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_triage_records_scenario_name
+    ON scenario_triage_records (scenario_name);
+
+CREATE TABLE IF NOT EXISTS scenario_proposals (
+    id TEXT PRIMARY KEY,
+    submitter_id INTEGER NOT NULL,
+    scenario_name TEXT NOT NULL,
+    proposal_patch_json TEXT NOT NULL,
+    raw_submission_json TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'submitted',
+    normalized_patch TEXT,
+    triage_record_id TEXT,
+    created_at_utc TEXT NOT NULL,
+    reviewed_at_utc TEXT,
+    FOREIGN KEY (submitter_id) REFERENCES scenario_submitters(id) ON DELETE RESTRICT,
+    FOREIGN KEY (triage_record_id) REFERENCES scenario_triage_records(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_proposals_scenario_name
+    ON scenario_proposals (scenario_name);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_proposals_status
+    ON scenario_proposals (status);
+
+CREATE TABLE IF NOT EXISTS scenario_supporting_runs (
+    id TEXT PRIMARY KEY,
+    proposal_id TEXT NOT NULL,
+    observed_payout INTEGER NOT NULL,
+    is_complete_evidence INTEGER NOT NULL CHECK (is_complete_evidence IN (0, 1)),
+    actions_json TEXT NOT NULL,
+    notes TEXT,
+    created_at_utc TEXT NOT NULL,
+    FOREIGN KEY (proposal_id) REFERENCES scenario_proposals(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_supporting_runs_proposal_id
+    ON scenario_supporting_runs (proposal_id);
+
+CREATE TABLE IF NOT EXISTS scenario_triage_record_members (
+    id TEXT PRIMARY KEY,
+    triage_record_id TEXT NOT NULL,
+    proposal_id TEXT NOT NULL UNIQUE,
+    created_at_utc TEXT NOT NULL,
+    FOREIGN KEY (triage_record_id) REFERENCES scenario_triage_records(id) ON DELETE CASCADE,
+    FOREIGN KEY (proposal_id) REFERENCES scenario_proposals(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_triage_record_members_triage_record_id
+    ON scenario_triage_record_members (triage_record_id);
+
+CREATE TABLE IF NOT EXISTS scenario_pr_events (
+    id TEXT PRIMARY KEY,
+    triage_record_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL,
+    FOREIGN KEY (triage_record_id) REFERENCES scenario_triage_records(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_pr_events_triage_record_id
+    ON scenario_pr_events (triage_record_id);

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,9 +1,13 @@
-import type { Fetcher } from '@cloudflare/workers-types'
+import type { D1Database, Fetcher } from '@cloudflare/workers-types'
 
 declare global {
   namespace App {
     interface Platform {
       env: {
+        SCENARIO_ADMIN_PASSWORD_HASH: string
+        SCENARIO_ADMIN_SESSION_SECRET: string
+        SCENARIO_ADMIN_USERNAME: string
+        SCENARIO_PROPOSALS_DB: D1Database
         TORN_PUBLIC_API_KEY: string
         TORN_MINIMAL_API_KEY: string
         ASSETS: Fetcher
@@ -12,6 +16,9 @@ declare global {
         waitUntil(promise: Promise<unknown>): void
       }
       caches: CacheStorage & { default: Cache }
+    }
+    interface Locals {
+      scenarioAdminUsername: string | null
     }
   }
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,12 @@
+import type { Handle } from '@sveltejs/kit';
+
+import { readScenarioAdminSession } from './lib/server/scenario-proposals/auth.js';
+
+export const handle: Handle = async ({ event, resolve }) => {
+    event.locals.scenarioAdminUsername = await readScenarioAdminSession(
+        event.cookies.get('scenario-admin-session') ?? null,
+        event.platform
+    );
+
+    return resolve(event);
+};

--- a/src/lib/server/scenario-proposals/auth.ts
+++ b/src/lib/server/scenario-proposals/auth.ts
@@ -1,0 +1,154 @@
+const COOKIE_NAME = 'scenario-admin-session';
+const SESSION_TTL_MS = 1000 * 60 * 60 * 12;
+
+export async function readScenarioAdminSession(
+    cookieValue: string | null,
+    platform: App.Platform | undefined
+): Promise<string | null> {
+    if (!cookieValue) return null;
+
+    const env = getScenarioAdminEnv(platform);
+    if (!env) return null;
+
+    const parts = cookieValue.split('.');
+    if (parts.length !== 2) return null;
+
+    const [payload, signature] = parts;
+    const expectedSignature = await signPayload(payload, env.SCENARIO_ADMIN_SESSION_SECRET);
+    if (!(await timingSafeEqual(signature, expectedSignature))) {
+        return null;
+    }
+
+    let parsed: { username?: string; exp?: number } | null = null;
+    try {
+        parsed = JSON.parse(decodeBase64Url(payload)) as { username?: string; exp?: number };
+    } catch {
+        return null;
+    }
+
+    if (!parsed?.username || typeof parsed.exp !== 'number' || parsed.exp <= Date.now()) {
+        return null;
+    }
+
+    if (parsed.username !== env.SCENARIO_ADMIN_USERNAME) {
+        return null;
+    }
+
+    return parsed.username;
+}
+
+export async function verifyScenarioAdminCredentials(
+    platform: App.Platform | undefined,
+    username: string,
+    password: string
+): Promise<boolean> {
+    const env = requireScenarioAdminEnv(platform);
+    if (username !== env.SCENARIO_ADMIN_USERNAME) {
+        return false;
+    }
+
+    const passwordHash = await sha256Hex(password);
+    return timingSafeEqual(passwordHash, env.SCENARIO_ADMIN_PASSWORD_HASH);
+}
+
+export async function createScenarioAdminSessionCookie(
+    platform: App.Platform | undefined,
+    username: string
+): Promise<{ name: string; value: string; maxAge: number }> {
+    const env = requireScenarioAdminEnv(platform);
+    const payload = encodeBase64Url(
+        JSON.stringify({
+            username,
+            exp: Date.now() + SESSION_TTL_MS
+        })
+    );
+    const signature = await signPayload(payload, env.SCENARIO_ADMIN_SESSION_SECRET);
+
+    return {
+        name: COOKIE_NAME,
+        value: `${payload}.${signature}`,
+        maxAge: SESSION_TTL_MS / 1000
+    };
+}
+
+export function clearScenarioAdminSessionCookie() {
+    return {
+        name: COOKIE_NAME,
+        value: '',
+        maxAge: 0
+    };
+}
+
+function getScenarioAdminEnv(platform: App.Platform | undefined) {
+    const env = platform?.env;
+    if (
+        !env?.SCENARIO_ADMIN_USERNAME ||
+        !env.SCENARIO_ADMIN_PASSWORD_HASH ||
+        !env.SCENARIO_ADMIN_SESSION_SECRET
+    ) {
+        return null;
+    }
+
+    return env;
+}
+
+function requireScenarioAdminEnv(platform: App.Platform | undefined) {
+    const env = getScenarioAdminEnv(platform);
+    if (!env) {
+        throw new Error('Scenario Admin secrets are not configured.');
+    }
+
+    return env;
+}
+
+async function signPayload(payload: string, secret: string): Promise<string> {
+    const key = await crypto.subtle.importKey(
+        'raw',
+        new TextEncoder().encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+    );
+    const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+    return encodeBytesBase64Url(new Uint8Array(signature));
+}
+
+async function sha256Hex(value: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function timingSafeEqual(left: string, right: string): Promise<boolean> {
+    const leftBytes = new TextEncoder().encode(left);
+    const rightBytes = new TextEncoder().encode(right);
+    if (leftBytes.length !== rightBytes.length) {
+        return false;
+    }
+
+    let mismatch = 0;
+    for (let index = 0; index < leftBytes.length; index += 1) {
+        mismatch |= leftBytes[index] ^ rightBytes[index];
+    }
+
+    return mismatch === 0;
+}
+
+function encodeBase64Url(value: string): string {
+    return encodeBytesBase64Url(new TextEncoder().encode(value));
+}
+
+function encodeBytesBase64Url(bytes: Uint8Array): string {
+    let binary = '';
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function decodeBase64Url(value: string): string {
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(value.length / 4) * 4, '=');
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+}

--- a/src/lib/server/scenario-proposals/db.ts
+++ b/src/lib/server/scenario-proposals/db.ts
@@ -1,0 +1,191 @@
+import { error } from '@sveltejs/kit';
+
+import type { SupportingRunEvidence, ScenarioProposalPatch, StoredScenarioProposal } from './types.js';
+
+interface SubmitterRow {
+    submitterId: number;
+    playerId: number;
+    playerName: string;
+}
+
+interface ProposalRow {
+    id: string;
+    scenario_name: string;
+    status: string;
+    created_at_utc: string;
+    player_id: number;
+    player_name: string;
+    submitter_id: number;
+    proposal_patch_json: string;
+}
+
+interface SupportingRunRow {
+    proposal_id: string;
+    observed_payout: number;
+    is_complete_evidence: number;
+    actions_json: string;
+    notes: string | null;
+}
+
+export async function findActiveSubmitterByToken(
+    platform: App.Platform | undefined,
+    submitToken: string
+): Promise<SubmitterRow | null> {
+    const db = requireScenarioProposalsDb(platform);
+    const tokenHash = await sha256Hex(submitToken);
+
+    const row = await db
+        .prepare(
+            `SELECT
+                s.id AS submitterId,
+                s.player_id AS playerId,
+                s.player_name AS playerName
+             FROM scenario_submit_tokens t
+             JOIN scenario_submitters s ON s.id = t.submitter_id
+             WHERE t.token_hash = ?
+               AND t.revoked_at_utc IS NULL
+               AND s.is_active = 1`
+        )
+        .bind(tokenHash)
+        .first<SubmitterRow>();
+
+    return row ?? null;
+}
+
+export async function createScenarioProposal(
+    platform: App.Platform | undefined,
+    input: {
+        submitterId: number;
+        scenarioName: string;
+        submitToken: string;
+        proposalPatch: ScenarioProposalPatch;
+        rawSubmission: unknown;
+        supportingRun: SupportingRunEvidence;
+    }
+): Promise<string> {
+    const db = requireScenarioProposalsDb(platform);
+    const proposalId = crypto.randomUUID();
+    const supportingRunId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const tokenHash = await sha256Hex(input.submitToken);
+
+    await db.batch([
+        db.prepare(
+            `INSERT INTO scenario_proposals (
+                id,
+                submitter_id,
+                scenario_name,
+                proposal_patch_json,
+                raw_submission_json,
+                status,
+                created_at_utc
+            ) VALUES (?, ?, ?, ?, ?, 'submitted', ?)`
+        ).bind(
+            proposalId,
+            input.submitterId,
+            input.scenarioName,
+            JSON.stringify(input.proposalPatch),
+            JSON.stringify(input.rawSubmission),
+            now
+        ),
+        db.prepare(
+            `INSERT INTO scenario_supporting_runs (
+                id,
+                proposal_id,
+                observed_payout,
+                is_complete_evidence,
+                actions_json,
+                notes,
+                created_at_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+        ).bind(
+            supportingRunId,
+            proposalId,
+            input.supportingRun.observedPayout,
+            input.supportingRun.isCompleteEvidence ? 1 : 0,
+            JSON.stringify(input.supportingRun.actions),
+            input.supportingRun.notes ?? null,
+            now
+        ),
+        db.prepare(
+            `UPDATE scenario_submit_tokens
+             SET last_used_at_utc = ?
+             WHERE token_hash = ?`
+        ).bind(now, tokenHash)
+    ]);
+
+    return proposalId;
+}
+
+export async function listScenarioProposals(platform: App.Platform | undefined): Promise<StoredScenarioProposal[]> {
+    const db = requireScenarioProposalsDb(platform);
+    const proposalRows = await db
+        .prepare(
+            `SELECT
+                p.id,
+                p.scenario_name,
+                p.status,
+                p.created_at_utc,
+                p.proposal_patch_json,
+                s.id AS submitter_id,
+                s.player_id,
+                s.player_name
+             FROM scenario_proposals p
+             JOIN scenario_submitters s ON s.id = p.submitter_id
+             ORDER BY p.created_at_utc DESC`
+        )
+        .all<ProposalRow>();
+
+    const supportingRunRows = await db
+        .prepare(
+            `SELECT
+                proposal_id,
+                observed_payout,
+                is_complete_evidence,
+                actions_json,
+                notes
+             FROM scenario_supporting_runs`
+        )
+        .all<SupportingRunRow>();
+
+    const runsByProposal = new Map<string, SupportingRunEvidence[]>();
+    for (const row of supportingRunRows.results ?? []) {
+        const existingRuns = runsByProposal.get(row.proposal_id) ?? [];
+        existingRuns.push({
+            observedPayout: row.observed_payout,
+            isCompleteEvidence: row.is_complete_evidence === 1,
+            actions: JSON.parse(row.actions_json) as SupportingRunEvidence['actions'],
+            notes: row.notes ?? null
+        });
+        runsByProposal.set(row.proposal_id, existingRuns);
+    }
+
+    return (proposalRows.results ?? []).map((row) => ({
+        id: row.id,
+        scenarioName: row.scenario_name,
+        status: row.status,
+        createdAtUtc: row.created_at_utc,
+        submitter: {
+            id: row.submitter_id,
+            playerId: row.player_id,
+            playerName: row.player_name
+        },
+        proposalPatch: JSON.parse(row.proposal_patch_json) as ScenarioProposalPatch,
+        supportingRuns: runsByProposal.get(row.id) ?? []
+    }));
+}
+
+function requireScenarioProposalsDb(platform: App.Platform | undefined) {
+    const db = platform?.env.SCENARIO_PROPOSALS_DB;
+    if (!db) {
+        throw error(500, 'SCENARIO_PROPOSALS_DB binding is not configured.');
+    }
+
+    return db;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+    const bytes = new TextEncoder().encode(value);
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/src/lib/server/scenario-proposals/form.ts
+++ b/src/lib/server/scenario-proposals/form.ts
@@ -1,0 +1,198 @@
+import { CATALOG, type ResourceId } from '../../../data/catalog.js';
+import { SCENARIOS, type ActionItem, type Scenario } from '../../../data/scenarios.js';
+import {
+    ACTION_BUCKETS,
+    type ActionBucket,
+    type ParsedScenarioProposalSubmission,
+    type ScenarioProposalPatch,
+    type SupportingRunEvidence,
+    type TimingValue
+} from './types.js';
+
+export class ScenarioProposalFormError extends Error {
+    readonly issues: string[];
+
+    constructor(issues: string[]) {
+        super('Scenario proposal validation failed.');
+        this.issues = issues;
+    }
+}
+
+export function formatActionItems(items?: ActionItem[]): string {
+    return (items ?? []).map((item) => `${item.resourceId},${item.qty}`).join('\n');
+}
+
+export function parseScenarioProposalSubmission(formData: FormData): ParsedScenarioProposalSubmission {
+    const issues: string[] = [];
+    const scenarioName = getTrimmedString(formData, 'scenarioName');
+    const submitToken = getTrimmedString(formData, 'submitToken');
+
+    if (!scenarioName) {
+        issues.push('Scenario is required.');
+    } else if (!SCENARIOS.some((scenario) => scenario.scenarioName === scenarioName)) {
+        issues.push(`Scenario "${scenarioName}" does not exist in the canonical Scenario Dataset.`);
+    }
+
+    if (!submitToken) {
+        issues.push('Scenario Submit Token is required.');
+    }
+
+    const proposalPatch = parseProposalPatch(formData, issues);
+    const supportingRun = parseSupportingRun(formData, issues);
+
+    if (issues.length > 0) {
+        throw new ScenarioProposalFormError(issues);
+    }
+
+    return {
+        scenarioName,
+        submitToken,
+        proposalPatch,
+        supportingRun,
+        rawSubmission: {
+            scenarioName,
+            proposalPatch,
+            supportingRun
+        }
+    };
+}
+
+export function buildScenarioFormCatalog() {
+    return SCENARIOS.map((scenario) => ({
+        scenarioName: scenario.scenarioName,
+        payout: scenario.payout,
+        notes: scenario.notes ?? null,
+        needsVerification: scenario.needsVerification ?? false,
+        stokeTime: scenario.actions.stokeTime ?? null,
+        dampenTime: scenario.actions.dampenTime ?? null,
+        actions: {
+            evidence: formatActionItems(scenario.actions.evidence),
+            ignite: formatActionItems(scenario.actions.ignite),
+            place: formatActionItems(scenario.actions.place),
+            stoke: formatActionItems(scenario.actions.stoke),
+            dampen: formatActionItems(scenario.actions.dampen)
+        }
+    }));
+}
+
+function parseProposalPatch(formData: FormData, issues: string[]): ScenarioProposalPatch {
+    const proposalPatch: ScenarioProposalPatch = {};
+    const proposalActions: Partial<Record<ActionBucket, ActionItem[]>> = {};
+
+    const payoutInput = getTrimmedString(formData, 'proposalPayout');
+    if (payoutInput) {
+        const payout = Number.parseInt(payoutInput, 10);
+        if (!Number.isInteger(payout) || payout <= 0) {
+            issues.push('Proposed payout must be a positive whole number.');
+        } else {
+            proposalPatch.payout = payout;
+        }
+    }
+
+    for (const bucket of ACTION_BUCKETS) {
+        if (formData.get(`proposal-${bucket}-replace`) !== 'on') continue;
+        proposalActions[bucket] = parseActionItems(getTrimmedString(formData, `proposal-${bucket}`), `proposal ${bucket}`, issues);
+    }
+
+    if (Object.keys(proposalActions).length > 0) {
+        proposalPatch.actions = proposalActions;
+    }
+
+    const stokeTime = parseTimingField(getTrimmedString(formData, 'proposalStokeTime'), 'stokeTime', issues);
+    if (stokeTime !== undefined) proposalPatch.stokeTime = stokeTime;
+
+    const dampenTime = parseTimingField(getTrimmedString(formData, 'proposalDampenTime'), 'dampenTime', issues);
+    if (dampenTime !== undefined) proposalPatch.dampenTime = dampenTime;
+
+    const needsVerification = getTrimmedString(formData, 'proposalNeedsVerification');
+    if (needsVerification === 'true') proposalPatch.needsVerification = true;
+    else if (needsVerification === 'false') proposalPatch.needsVerification = false;
+    else if (needsVerification && needsVerification !== 'no-change') issues.push('needsVerification must be no-change, true, or false.');
+
+    if (formData.get('proposal-notes-replace') === 'on') {
+        proposalPatch.notes = getTrimmedString(formData, 'proposalNotes') || null;
+    }
+
+    if (Object.keys(proposalPatch).length === 0) {
+        issues.push('Proposal must include at least one canonical field change.');
+    }
+
+    return proposalPatch;
+}
+
+function parseSupportingRun(formData: FormData, issues: string[]): SupportingRunEvidence {
+    const observedPayoutInput = getTrimmedString(formData, 'supportingRunObservedPayout');
+    const observedPayout = Number.parseInt(observedPayoutInput, 10);
+    if (!observedPayoutInput || !Number.isInteger(observedPayout) || observedPayout <= 0) {
+        issues.push('Supporting run observed payout must be a positive whole number.');
+    }
+
+    const actions: Partial<Record<ActionBucket, ActionItem[]>> = {};
+    for (const bucket of ACTION_BUCKETS) {
+        const items = parseActionItems(getTrimmedString(formData, `supportingRun-${bucket}`), `supporting run ${bucket}`, issues);
+        if (items.length > 0) {
+            actions[bucket] = items;
+        }
+    }
+
+    if (Object.keys(actions).length === 0) {
+        issues.push('Supporting run evidence must include at least one action bucket.');
+    }
+
+    return {
+        observedPayout: Number.isInteger(observedPayout) && observedPayout > 0 ? observedPayout : 0,
+        isCompleteEvidence: formData.get('supportingRunIsCompleteEvidence') === 'on',
+        actions,
+        notes: getTrimmedString(formData, 'supportingRunNotes') || null
+    };
+}
+
+function parseActionItems(value: string, label: string, issues: string[]): ActionItem[] {
+    if (!value) return [];
+
+    const lines = value
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+    const items: ActionItem[] = [];
+
+    for (const line of lines) {
+        const [resourceIdRaw, qtyRaw, ...rest] = line.split(',').map((part) => part.trim());
+        if (rest.length > 0 || !resourceIdRaw || !qtyRaw) {
+            issues.push(`Each ${label} line must use "resourceId,qty". Invalid line: "${line}".`);
+            continue;
+        }
+
+        if (!(resourceIdRaw in CATALOG)) {
+            issues.push(`Unknown resourceId "${resourceIdRaw}" in ${label}.`);
+            continue;
+        }
+
+        const qty = Number.parseInt(qtyRaw, 10);
+        if (!Number.isInteger(qty) || qty <= 0) {
+            issues.push(`Quantity for ${label} must be a positive whole number. Invalid line: "${line}".`);
+            continue;
+        }
+
+        items.push({
+            resourceId: resourceIdRaw as ResourceId,
+            qty
+        });
+    }
+
+    return items;
+}
+
+function parseTimingField(value: string, label: string, issues: string[]): TimingValue | null | undefined {
+    if (!value || value === 'no-change') return undefined;
+    if (value === 'clear') return null;
+    if (value === 'early' || value === 'late') return value;
+    issues.push(`${label} must be no-change, early, late, or clear.`);
+    return undefined;
+}
+
+function getTrimmedString(formData: FormData, key: string): string {
+    const value = formData.get(key);
+    return typeof value === 'string' ? value.trim() : '';
+}

--- a/src/lib/server/scenario-proposals/types.ts
+++ b/src/lib/server/scenario-proposals/types.ts
@@ -1,0 +1,48 @@
+import type { ActionItem, ScenarioActions } from '../../../data/scenarios.js';
+
+export const ACTION_BUCKETS = ['evidence', 'ignite', 'place', 'stoke', 'dampen'] as const;
+
+export type ActionBucket = (typeof ACTION_BUCKETS)[number];
+export type TimingValue = NonNullable<ScenarioActions['stokeTime']>;
+
+export interface ScenarioProposalPatch {
+    payout?: number;
+    actions?: Partial<Record<ActionBucket, ActionItem[]>>;
+    stokeTime?: TimingValue | null;
+    dampenTime?: TimingValue | null;
+    needsVerification?: boolean;
+    notes?: string | null;
+}
+
+export interface SupportingRunEvidence {
+    observedPayout: number;
+    isCompleteEvidence: boolean;
+    actions: Partial<Record<ActionBucket, ActionItem[]>>;
+    notes?: string | null;
+}
+
+export interface ParsedScenarioProposalSubmission {
+    scenarioName: string;
+    submitToken: string;
+    proposalPatch: ScenarioProposalPatch;
+    supportingRun: SupportingRunEvidence;
+    rawSubmission: {
+        scenarioName: string;
+        proposalPatch: ScenarioProposalPatch;
+        supportingRun: SupportingRunEvidence;
+    };
+}
+
+export interface StoredScenarioProposal {
+    id: string;
+    scenarioName: string;
+    status: string;
+    createdAtUtc: string;
+    submitter: {
+        id: number;
+        playerId: number;
+        playerName: string;
+    };
+    proposalPatch: ScenarioProposalPatch;
+    supportingRuns: SupportingRunEvidence[];
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,10 @@
 <main style="font-family: sans-serif; padding: 2rem;">
   <h1>Balaclava</h1>
 
+  <h2>Scenario Proposals</h2>
+  <p><a href="/scenario-proposals">/scenario-proposals</a> submitter form</p>
+  <p><a href="/scenario-proposals/admin/login">/scenario-proposals/admin/login</a> protected inbox</p>
+
   <h2>Personal Signatures</h2>
   <p><a href="/api/sigs/906148">/api/sigs/906148</a> (Yukio)</p>
   <img src="/api/sigs/906148" alt="Yukio signature" width="600" height="100" style="display:block;margin-top:1rem;border-radius:8px;" />

--- a/src/routes/scenario-proposals/+page.server.ts
+++ b/src/routes/scenario-proposals/+page.server.ts
@@ -1,0 +1,53 @@
+import { fail } from '@sveltejs/kit';
+
+import { createScenarioProposal, findActiveSubmitterByToken } from '../../lib/server/scenario-proposals/db.js';
+import {
+    buildScenarioFormCatalog,
+    parseScenarioProposalSubmission,
+    ScenarioProposalFormError
+} from '../../lib/server/scenario-proposals/form.js';
+
+export const load = async () => {
+    return {
+        scenarios: buildScenarioFormCatalog()
+    };
+};
+
+export const actions = {
+    default: async ({ request, platform }) => {
+        const formData = await request.formData();
+
+        try {
+            const submission = parseScenarioProposalSubmission(formData);
+            const submitter = await findActiveSubmitterByToken(platform, submission.submitToken);
+            if (!submitter) {
+                return fail(401, {
+                    message: 'Scenario Submit Token is invalid or revoked.'
+                });
+            }
+
+            await createScenarioProposal(platform, {
+                submitterId: submitter.submitterId,
+                scenarioName: submission.scenarioName,
+                submitToken: submission.submitToken,
+                proposalPatch: submission.proposalPatch,
+                rawSubmission: submission.rawSubmission,
+                supportingRun: submission.supportingRun
+            });
+
+            return {
+                success: true,
+                message: `Scenario Proposal stored for ${submission.scenarioName}.`
+            };
+        } catch (error) {
+            if (error instanceof ScenarioProposalFormError) {
+                return fail(400, {
+                    message: 'Fix the validation errors and resubmit.',
+                    issues: error.issues
+                });
+            }
+
+            throw error;
+        }
+    }
+};

--- a/src/routes/scenario-proposals/+page.svelte
+++ b/src/routes/scenario-proposals/+page.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+  import type { ActionBucket } from '../../lib/server/scenario-proposals/types.js';
+
+  export let data: {
+    scenarios: Array<{
+      scenarioName: string;
+      payout: number;
+      notes: string | null;
+      needsVerification: boolean;
+      stokeTime: 'early' | 'late' | null;
+      dampenTime: 'early' | 'late' | null;
+      actions: Record<ActionBucket, string>;
+    }>;
+  };
+
+  export let form:
+    | {
+        success?: boolean;
+        message?: string;
+        issues?: string[];
+      }
+    | undefined;
+
+  const actionBuckets: ActionBucket[] = ['evidence', 'ignite', 'place', 'stoke', 'dampen'];
+  let selectedScenarioName = data.scenarios[0]?.scenarioName ?? '';
+
+  $: selectedScenario = data.scenarios.find((scenario) => scenario.scenarioName === selectedScenarioName) ?? null;
+
+  function labelBucket(bucket: ActionBucket) {
+    return bucket.charAt(0).toUpperCase() + bucket.slice(1);
+  }
+</script>
+
+<svelte:head>
+  <title>Scenario Proposal Form | Balaclava</title>
+</svelte:head>
+
+<main style="font-family: sans-serif; padding: 2rem; max-width: 1100px; margin: 0 auto;">
+  <h1>Scenario Proposal Form</h1>
+  <p>
+    Submit proposed edits for an existing canonical <code>Scenario</code>. Git remains the source of truth; this form only writes to the
+    D1-backed inbox for Yukio to review.
+  </p>
+  <p><a href="/scenario-proposals/admin/login">Scenario Admin inbox</a></p>
+
+  {#if form?.message}
+    <p style={`padding: 0.75rem 1rem; border-radius: 8px; ${form.success ? 'background:#e8fff1;color:#134b27;border:1px solid #9ddbb2;' : 'background:#fff5f5;color:#7a1f1f;border:1px solid #efb3b3;'}`}>
+      {form.message}
+    </p>
+  {/if}
+
+  {#if form?.issues?.length}
+    <div style="background:#fff8e8;border:1px solid #e8c96f;border-radius:8px;padding:1rem;margin:1rem 0;">
+      <strong>Submission errors</strong>
+      <ul style="margin:0.75rem 0 0 1.25rem;">
+        {#each form.issues as issue}
+          <li>{issue}</li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+
+  <form method="POST" style="display:grid; gap:1.5rem;">
+    <section style="border:1px solid #ddd;border-radius:12px;padding:1rem;">
+      <h2 style="margin-top:0;">Access</h2>
+      <label style="display:grid; gap:0.35rem;">
+        <span>Scenario Submit Token</span>
+        <input
+          name="submitToken"
+          type="password"
+          autocomplete="off"
+          spellcheck="false"
+          required
+          style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;"
+        />
+      </label>
+    </section>
+
+    <section style="border:1px solid #ddd;border-radius:12px;padding:1rem;">
+      <h2 style="margin-top:0;">Canonical Scenario</h2>
+      <label style="display:grid; gap:0.35rem;">
+        <span>Scenario</span>
+        <select bind:value={selectedScenarioName} name="scenarioName" required style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;">
+          {#each data.scenarios as scenario}
+            <option value={scenario.scenarioName}>{scenario.scenarioName}</option>
+          {/each}
+        </select>
+      </label>
+
+      {#if selectedScenario}
+        <div style="margin-top:1rem;background:#f8f8f8;border-radius:10px;padding:1rem;">
+          <p style="margin:0 0 0.5rem;"><strong>Payout:</strong> ${selectedScenario.payout.toLocaleString()}</p>
+          <p style="margin:0 0 0.5rem;"><strong>needsVerification:</strong> {selectedScenario.needsVerification ? 'true' : 'false'}</p>
+          <p style="margin:0 0 0.5rem;"><strong>stokeTime:</strong> {selectedScenario.stokeTime ?? 'unset'}</p>
+          <p style="margin:0 0 0.5rem;"><strong>dampenTime:</strong> {selectedScenario.dampenTime ?? 'unset'}</p>
+          <p style="margin:0 0 0.5rem;"><strong>Notes:</strong> {selectedScenario.notes ?? 'none'}</p>
+
+          <div style="display:grid; gap:0.75rem; margin-top:0.75rem;">
+            {#each actionBuckets as bucket}
+              <div>
+                <strong>{labelBucket(bucket)}:</strong>
+                <pre style="margin:0.4rem 0 0;padding:0.75rem;background:white;border:1px solid #e2e2e2;border-radius:8px;white-space:pre-wrap;">{selectedScenario.actions[bucket] || 'none'}</pre>
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/if}
+    </section>
+
+    <section style="border:1px solid #ddd;border-radius:12px;padding:1rem;">
+      <h2 style="margin-top:0;">Proposed Canonical Changes</h2>
+      <p style="margin-top:0;">Leave fields in <code>no-change</code> mode unless you intend to replace them. Action textareas use one line per item: <code>resourceId,qty</code>.</p>
+
+      <div style="display:grid; gap:1rem; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));">
+        <label style="display:grid; gap:0.35rem;">
+          <span>Proposed payout</span>
+          <input name="proposalPayout" type="number" min="1" step="1" style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;" />
+        </label>
+
+        <label style="display:grid; gap:0.35rem;">
+          <span>needsVerification</span>
+          <select name="proposalNeedsVerification" style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;">
+            <option value="no-change">no-change</option>
+            <option value="true">true</option>
+            <option value="false">false</option>
+          </select>
+        </label>
+
+        <label style="display:grid; gap:0.35rem;">
+          <span>stokeTime</span>
+          <select name="proposalStokeTime" style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;">
+            <option value="no-change">no-change</option>
+            <option value="early">early</option>
+            <option value="late">late</option>
+            <option value="clear">clear</option>
+          </select>
+        </label>
+
+        <label style="display:grid; gap:0.35rem;">
+          <span>dampenTime</span>
+          <select name="proposalDampenTime" style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;">
+            <option value="no-change">no-change</option>
+            <option value="early">early</option>
+            <option value="late">late</option>
+            <option value="clear">clear</option>
+          </select>
+        </label>
+      </div>
+
+      <label style="display:flex; gap:0.5rem; align-items:center; margin-top:1rem;">
+        <input type="checkbox" name="proposal-notes-replace" />
+        <span>Replace canonical notes</span>
+      </label>
+      <textarea
+        name="proposalNotes"
+        rows="4"
+        placeholder="Leave blank with 'Replace canonical notes' checked to clear notes."
+        style="width:100%;margin-top:0.5rem;padding:0.75rem;border:1px solid #bbb;border-radius:8px;"
+      ></textarea>
+
+      <div style="display:grid; gap:1rem; margin-top:1rem; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));">
+        {#each actionBuckets as bucket}
+          <div style="display:grid; gap:0.5rem;">
+            <label style="display:flex; gap:0.5rem; align-items:center;">
+              <input type="checkbox" name={`proposal-${bucket}-replace`} />
+              <span>Replace {bucket}</span>
+            </label>
+            <textarea
+              name={`proposal-${bucket}`}
+              rows="5"
+              placeholder="resourceId,qty"
+              style="padding:0.75rem;border:1px solid #bbb;border-radius:8px;"
+            ></textarea>
+          </div>
+        {/each}
+      </div>
+    </section>
+
+    <section style="border:1px solid #ddd;border-radius:12px;padding:1rem;">
+      <h2 style="margin-top:0;">Supporting Run Evidence</h2>
+      <p style="margin-top:0;">Issue #13 persists raw structured evidence in D1. Include the action buckets you actually ran and the observed payout you saw.</p>
+
+      <div style="display:grid; gap:1rem; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));">
+        <label style="display:grid; gap:0.35rem;">
+          <span>Observed payout</span>
+          <input
+            name="supportingRunObservedPayout"
+            type="number"
+            min="1"
+            step="1"
+            required
+            style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;"
+          />
+        </label>
+
+        <label style="display:flex; gap:0.5rem; align-items:center;">
+          <input type="checkbox" name="supportingRunIsCompleteEvidence" />
+          <span>This run includes complete evidence for action-winner logic</span>
+        </label>
+      </div>
+
+      <div style="display:grid; gap:1rem; margin-top:1rem; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));">
+        {#each actionBuckets as bucket}
+          <label style="display:grid; gap:0.35rem;">
+            <span>{labelBucket(bucket)}</span>
+            <textarea
+              name={`supportingRun-${bucket}`}
+              rows="5"
+              placeholder="resourceId,qty"
+              style="padding:0.75rem;border:1px solid #bbb;border-radius:8px;"
+            ></textarea>
+          </label>
+        {/each}
+      </div>
+
+      <label style="display:grid; gap:0.35rem; margin-top:1rem;">
+        <span>Run notes</span>
+        <textarea
+          name="supportingRunNotes"
+          rows="4"
+          placeholder="Anything the Scenario Admin should know about the observed run."
+          style="padding:0.75rem;border:1px solid #bbb;border-radius:8px;"
+        ></textarea>
+      </label>
+    </section>
+
+    <button type="submit" style="padding:0.9rem 1.2rem;border:none;border-radius:10px;background:#111;color:white;font-weight:700;cursor:pointer;">
+      Submit Scenario Proposal
+    </button>
+  </form>
+</main>

--- a/src/routes/scenario-proposals/admin/+page.server.ts
+++ b/src/routes/scenario-proposals/admin/+page.server.ts
@@ -1,0 +1,30 @@
+import { redirect } from '@sveltejs/kit';
+
+import { clearScenarioAdminSessionCookie } from '../../../lib/server/scenario-proposals/auth.js';
+import { listScenarioProposals } from '../../../lib/server/scenario-proposals/db.js';
+
+export const load = async ({ locals, platform }) => {
+    if (!locals.scenarioAdminUsername) {
+        throw redirect(303, '/scenario-proposals/admin/login');
+    }
+
+    return {
+        scenarioAdminUsername: locals.scenarioAdminUsername,
+        proposals: await listScenarioProposals(platform)
+    };
+};
+
+export const actions = {
+    logout: async ({ cookies, url }) => {
+        const sessionCookie = clearScenarioAdminSessionCookie();
+        cookies.set(sessionCookie.name, sessionCookie.value, {
+            path: '/',
+            httpOnly: true,
+            sameSite: 'strict',
+            secure: url.protocol === 'https:',
+            maxAge: sessionCookie.maxAge
+        });
+
+        throw redirect(303, '/scenario-proposals/admin/login');
+    }
+};

--- a/src/routes/scenario-proposals/admin/+page.svelte
+++ b/src/routes/scenario-proposals/admin/+page.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import type { StoredScenarioProposal } from '../../../lib/server/scenario-proposals/types.js';
+
+  export let data: {
+    scenarioAdminUsername: string;
+    proposals: StoredScenarioProposal[];
+  };
+
+  function formatJson(value: unknown) {
+    return JSON.stringify(value, null, 2);
+  }
+</script>
+
+<svelte:head>
+  <title>Scenario Proposal Inbox | Balaclava</title>
+</svelte:head>
+
+<main style="font-family: sans-serif; padding: 2rem; max-width: 1100px; margin: 0 auto;">
+  <div style="display:flex; justify-content:space-between; gap:1rem; align-items:flex-start; flex-wrap:wrap;">
+    <div>
+      <h1 style="margin-bottom:0.4rem;">Scenario Proposal Inbox</h1>
+      <p style="margin-top:0;">Signed in as <strong>{data.scenarioAdminUsername}</strong>. This issue-13 slice shows the raw D1 inbox before grouping and PR write-back.</p>
+    </div>
+
+    <form method="POST">
+      <button type="submit" name="/logout" formaction="?/logout" style="padding:0.8rem 1rem;border:1px solid #333;border-radius:10px;background:white;cursor:pointer;">
+        Sign out
+      </button>
+    </form>
+  </div>
+
+  <p><a href="/scenario-proposals">Open submitter form</a></p>
+
+  {#if data.proposals.length === 0}
+    <p style="padding:1rem;border:1px dashed #bbb;border-radius:10px;">No proposals stored yet.</p>
+  {:else}
+    <div style="display:grid; gap:1rem;">
+      {#each data.proposals as proposal}
+        <article style="border:1px solid #ddd;border-radius:12px;padding:1rem;">
+          <div style="display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap;">
+            <div>
+              <h2 style="margin:0 0 0.4rem;">{proposal.scenarioName}</h2>
+              <p style="margin:0;"><strong>Status:</strong> {proposal.status}</p>
+              <p style="margin:0;"><strong>Created:</strong> {proposal.createdAtUtc}</p>
+              <p style="margin:0;"><strong>Submitter:</strong> {proposal.submitter.playerName} ({proposal.submitter.playerId})</p>
+            </div>
+            <p style="margin:0;"><strong>Proposal ID:</strong> <code>{proposal.id}</code></p>
+          </div>
+
+          <div style="display:grid; gap:1rem; grid-template-columns:repeat(auto-fit, minmax(300px, 1fr)); margin-top:1rem;">
+            <div>
+              <h3 style="margin-top:0;">Proposed canonical patch</h3>
+              <pre style="margin:0;padding:0.75rem;background:#f8f8f8;border:1px solid #e2e2e2;border-radius:8px;white-space:pre-wrap;">{formatJson(proposal.proposalPatch)}</pre>
+            </div>
+
+            <div>
+              <h3 style="margin-top:0;">Supporting runs</h3>
+              {#each proposal.supportingRuns as supportingRun, index}
+                <div style="margin-bottom:0.75rem;">
+                  <p style="margin:0 0 0.35rem;"><strong>Run {index + 1}:</strong> payout ${supportingRun.observedPayout.toLocaleString()} • complete evidence {supportingRun.isCompleteEvidence ? 'yes' : 'no'}</p>
+                  <pre style="margin:0;padding:0.75rem;background:#f8f8f8;border:1px solid #e2e2e2;border-radius:8px;white-space:pre-wrap;">{formatJson(supportingRun)}</pre>
+                </div>
+              {/each}
+            </div>
+          </div>
+        </article>
+      {/each}
+    </div>
+  {/if}
+</main>

--- a/src/routes/scenario-proposals/admin/login/+page.server.ts
+++ b/src/routes/scenario-proposals/admin/login/+page.server.ts
@@ -1,0 +1,52 @@
+import { fail, redirect } from '@sveltejs/kit';
+
+import {
+    clearScenarioAdminSessionCookie,
+    createScenarioAdminSessionCookie,
+    verifyScenarioAdminCredentials
+} from '../../../../lib/server/scenario-proposals/auth.js';
+
+export const load = async ({ locals }) => {
+    if (locals.scenarioAdminUsername) {
+        throw redirect(303, '/scenario-proposals/admin');
+    }
+};
+
+export const actions = {
+    default: async ({ request, cookies, platform, url }) => {
+        const formData = await request.formData();
+        const usernameEntry = formData.get('username');
+        const passwordEntry = formData.get('password');
+        const username = typeof usernameEntry === 'string' ? usernameEntry.trim() : '';
+        const password = typeof passwordEntry === 'string' ? passwordEntry : '';
+        const secure = url.protocol === 'https:';
+
+        if (!username || !password) {
+            return fail(400, { message: 'Username and password are required.' });
+        }
+
+        const isValid = await verifyScenarioAdminCredentials(platform, username, password);
+        if (!isValid) {
+            cookies.set(clearScenarioAdminSessionCookie().name, clearScenarioAdminSessionCookie().value, {
+                path: '/',
+                httpOnly: true,
+                sameSite: 'strict',
+                secure,
+                maxAge: 0
+            });
+
+            return fail(401, { message: 'Invalid Scenario Admin credentials.' });
+        }
+
+        const sessionCookie = await createScenarioAdminSessionCookie(platform, username);
+        cookies.set(sessionCookie.name, sessionCookie.value, {
+            path: '/',
+            httpOnly: true,
+            sameSite: 'strict',
+            secure,
+            maxAge: sessionCookie.maxAge
+        });
+
+        throw redirect(303, '/scenario-proposals/admin');
+    }
+};

--- a/src/routes/scenario-proposals/admin/login/+page.svelte
+++ b/src/routes/scenario-proposals/admin/login/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  export let form:
+    | {
+        message?: string;
+      }
+    | undefined;
+</script>
+
+<svelte:head>
+  <title>Scenario Admin Login | Balaclava</title>
+</svelte:head>
+
+<main style="font-family: sans-serif; padding: 2rem; max-width: 480px; margin: 0 auto;">
+  <h1>Scenario Admin Login</h1>
+  <p>Authenticate with the single Scenario Admin credential pair configured in Cloudflare secrets.</p>
+
+  {#if form?.message}
+    <p style="padding:0.75rem 1rem;border-radius:8px;background:#fff5f5;color:#7a1f1f;border:1px solid #efb3b3;">
+      {form.message}
+    </p>
+  {/if}
+
+  <form method="POST" style="display:grid; gap:1rem; margin-top:1rem;">
+    <label style="display:grid; gap:0.35rem;">
+      <span>Username</span>
+      <input name="username" autocomplete="username" required style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;" />
+    </label>
+
+    <label style="display:grid; gap:0.35rem;">
+      <span>Password</span>
+      <input name="password" type="password" autocomplete="current-password" required style="padding:0.7rem;border:1px solid #bbb;border-radius:8px;" />
+    </label>
+
+    <button type="submit" style="padding:0.9rem 1.2rem;border:none;border-radius:10px;background:#111;color:white;font-weight:700;cursor:pointer;">
+      Sign in
+    </button>
+  </form>
+</main>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,3 +2,12 @@ name = "balaclava"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".svelte-kit/cloudflare"
+
+# Configure after:
+#   pnpm exec wrangler d1 create balaclava-scenario-proposals
+# Then uncomment and replace <database_id>.
+# [[d1_databases]]
+# binding = "SCENARIO_PROPOSALS_DB"
+# database_name = "balaclava-scenario-proposals"
+# database_id = "<database_id>"
+# migrations_dir = "migrations"


### PR DESCRIPTION
## Summary
- add the issue-13 Scenario Proposal intake flow with D1 persistence for existing canonical Scenarios
- add Workers-safe submit-token validation and single-admin session auth for the protected inbox
- document Cloudflare D1, secrets, migrations, and submitter/token seeding setup

## What changed
- add the initial D1 schema for scenario submitters, tokens, proposals, supporting runs, triage records, triage members, and PR events
- add `/scenario-proposals` with validation for structured proposal patches and supporting run evidence
- add `/scenario-proposals/admin/login` and `/scenario-proposals/admin` for the protected raw inbox view
- wire new app/platform types and request-time session loading for Scenario Admin auth
- add setup docs and a commented `wrangler.toml` D1 binding block

## Verification
- `pnpm check`
- `pnpm build`

Closes #13